### PR TITLE
Treasure hunter improvements (plus efficiency tweaks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,14 +238,15 @@ This I had worked quite a bit on, and I'm quite happy with what it's capable of 
 
 What this script adds is a new top row below the mining layer, as shown:<br>
 
-![](https://i.imgur.com/0DzjmOM.png)
+![](https://user-images.githubusercontent.com/12092270/184208280-9ef59caf-5b0f-402a-be12-049cdad8beb3.png)
 
 There's a lot to go over and explained with this Auto Miner, but I'll try my best to explain it all:
 
 **• Auto Mine** - This will turn the Auto Miner On/Off. The Auto Miner uses bombs to automatically mine.<br>
-**• Auto Small Restore** - This will automatically use Small Restores as well as buy them while it's active (only when Auto Mine is running). It will also only ever buy them when you have 0 Small Restores and when they cost 30,000 (base price). Knowing that, this is best used anywhere you can one-shot Pokémon (so the price penalty in the Shop is constantly decreasing).<br>
-**• 1st Input Field** - Here you can enter a money value at which Small Restores should stop Auto Buying. This will help you not drain your money.<br>
-**• 2nd Input Field** - This is basically an Auto Skipper. You can enter the minimum value of items you would like to look for in new layers. If there are fewer items in a layer than your desired input, it will be skipped (if you have any skips available).
+**• Auto Small Restore** - This will automatically buy and use Small Restores when low on energy (only while Auto Mine is running). It will only buy them when there are no Restores in your inventory and when they cost 30,000 (base price). Knowing that, this is best used anywhere you can one-shot Pokémon, so the price penalty in the Shop is constantly decreasing.<br>
+**• 1st Input Field** - The money amount below which the script will stop auto-buying Small Restores, so it won't drain all your money.<br>
+**• Dropdown Menu - This menu lets you choose a type of item for the Treasure Hunter mode. While you have skips available, the Treasure Hunter will survey layers and skip them if they contain too few of your desired item type. The Treasure Hunter's default setting skips layers with too few total items.
+**• 2nd Input Field** - The minimum number of your desired item type (or total items) for the Treasure Hunter. If the layer has fewer of the set item type the Treasure Hunter will skip it. Set this field to 0 to not skip any layers.
 
 As of 1.1 this also includes 2 more additional features into the Treasures tab of the Underground as shown below:<br>
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ There's a lot to go over and explained with this Auto Miner, but I'll try my bes
 **• Auto Mine** - This will turn the Auto Miner On/Off. The Auto Miner uses bombs to automatically mine.<br>
 **• Auto Small Restore** - This will automatically buy and use Small Restores when low on energy (only while Auto Mine is running). It will only buy them when there are no Restores in your inventory and when they cost 30,000 (base price). Knowing that, this is best used anywhere you can one-shot Pokémon, so the price penalty in the Shop is constantly decreasing.<br>
 **• 1st Input Field** - The money amount below which the script will stop auto-buying Small Restores, so it won't drain all your money.<br>
-**• Dropdown Menu - This menu lets you choose a type of item for the Treasure Hunter mode. While you have skips available, the Treasure Hunter will survey layers and skip them if they contain too few of your desired item type. The Treasure Hunter's default setting skips layers with too few total items.
-**• 2nd Input Field** - The minimum number of your desired item type (or total items) for the Treasure Hunter. If the layer has fewer of the set item type the Treasure Hunter will skip it. Set this field to 0 to not skip any layers.
+**• Dropdown Menu** - This menu lets you choose a type of item for the Treasure Hunter mode. While you have skips available, the Treasure Hunter will survey layers and skip them if they contain too few of your desired item type. The Treasure Hunter's default setting skips layers with too few total items.<br>
+**• 2nd Input Field** - The minimum number of your desired item type (or total items) for the Treasure Hunter. If the layer has fewer of the set item type the Treasure Hunter will skip it. Set this field to 0 to not skip any layers.<br>
 
 As of 1.1 this also includes 2 more additional features into the Treasures tab of the Underground as shown below:<br>
 

--- a/enhancedautomine.user.js
+++ b/enhancedautomine.user.js
@@ -3,24 +3,25 @@
 // @namespace   Pokeclicker Scripts
 // @match       https://www.pokeclicker.com/
 // @grant       none
-// @version     1.7
-// @author      Ephenia (Credit: falcon71, KarmaAlex)
+// @version     1.8
+// @author      Ephenia (Credit: falcon71, KarmaAlex, umbralOptimatum)
 // @description Automatically mines the Underground with Bombs. Features adjustable settings as well.
 // @updateURL   https://raw.githubusercontent.com/Ephenia/Pokeclicker-Scripts/master/enhancedautomine.user.js
 // ==/UserScript==
+
+const SCRIPT_VERSION = 1.8
 
 var mineState;
 var smallRestoreState;
 var awaitAutoMine;
 var setThreshold;
 var autoMineTimer;
-var resetInProgress;
 var busyMining;
-var autoMineSkip;
+//var autoMineSkip;
 var layersMined;
 var sellTreasureState;
 var treasureHunter;
-const treasureItems = ['Evolution Items', 'Gem Plates', 'Shards', 'Fossils'];
+var itemThreshold;
 
 function initAutoMine() {
     if (mineState) {
@@ -29,30 +30,34 @@ function initAutoMine() {
         }, 1000);
     }
 
-    setThreshold = +setThreshold
-    resetInProgress = false;
+    setThreshold = +setThreshold;
     localStorage.setItem("undergroundLayersMined", App.game.statistics.undergroundLayersMined());
     layersMined = JSON.parse(localStorage.getItem('undergroundLayersMined'));
 
     const minerHTML = document.createElement("div");
     minerHTML.innerHTML = `<button id="auto-mine-start" class="col-12 col-md-2 btn btn-${mineState ? 'success' : 'danger'}">Auto Mine [${mineState ? 'ON' : 'OFF'}]</button>
-<button id="small-restore-start" class="col-12 col-md-2 btn btn-${smallRestoreState ? 'success' : 'danger'}">Auto Small Restore [${smallRestoreState ? 'ON' : 'OFF'}]</button>
-<select id="treasure-hunter" class="col-12 col-md-2 btn">
-  <option value="-1">Selected Item</option>
-  <option value="0">Evolution Items</option>
-  <option value="1">Gem Plates</option>
-  <option value="2">Shards</option>
-  <option value="3">Fossils</option>
-</select>
+<button id="small-restore-start" class="col-12 col-md-3 btn btn-${smallRestoreState ? 'success' : 'danger'}">Auto Small Restore [${smallRestoreState ? 'ON' : 'OFF'}]</button>
 <div id="threshold-input" class="col-12 col-md-3 btn-secondary"><img title="Money" src="assets/images/currency/money.svg" height="25px">
-<input title="Enter in a value where Small Restores will stop being bought at." type="text" id="small-restore"></div>
-<div id="skip-input" class="col-12 col-md-3 btn-secondary">
-<input title="Auto skipping occurs if the max items in a layer is lower than the value put here." type="text" id="auto-skip"></div>`
+<input title="Value at which to stop buying Small Restores." type="text" id="small-restore"></div>
+<select id="treasure-hunter" class="col-12 col-md-2 btn">
+  <option value="-1">All Items</option>
+  <option value="0">Fossils</option>
+  <option value="1">Evolution Items</option>
+  <option value="2">Gem Plates</option>
+  <option value="3">Shards</option>
+  <option value="4">Diamond Value</option>
+</select>
+<div id="item-threshold-input" class="col-12 col-md-2 btn-secondary"><img id="treasure-image" src="assets/images/currency/money.svg" height="25px">
+<input title="Skips layers with fewer target items than this value." type="text" id="item-threshold"></div>`
+    /* <div id="skip-input" class="col-12 col-md-3 btn-secondary">
+    <input title="Automatically skips layers with fewer items than this value." type="text" id="auto-skip"></div> */
     document.querySelectorAll('#mineBody + div')[0].prepend(minerHTML);
     $("#auto-mine-start").unwrap();
     document.getElementById('small-restore').value = setThreshold.toLocaleString('en-US');
     document.getElementById('treasure-hunter').value = treasureHunter;
-    document.getElementById('auto-skip').value = autoMineSkip.toLocaleString('en-US');
+    document.getElementById('item-threshold').value = itemThreshold.toLocaleString('en-US');
+    setTreasureImage();
+    //document.getElementById('auto-skip').value = autoMineSkip.toLocaleString('en-US');
     const autoSeller = document.createElement("div");
     autoSeller.innerHTML = `<div>
     <button id="auto-sell-treasure" class="col-12 col-md-3 btn btn-${sellTreasureState ? 'success' : 'danger'}">Auto Sell Treasure [${sellTreasureState ? 'ON' : 'OFF'}]</button>
@@ -69,16 +74,25 @@ function initAutoMine() {
         localStorage.setItem("autoBuyThreshold", setThreshold);
         event.target.value = setThreshold.toLocaleString('en-US');
     });
+    document.querySelector('#item-threshold').addEventListener('input', event => {
+        itemThreshold = +event.target.value.replace(/[A-Za-z!@#$%^&*()]/g, '').replace(/[,]/g, "");
+        localStorage.setItem("itemThreshold", itemThreshold);
+        event.target.value = itemThreshold.toLocaleString('en-US');
+    });
+    /*
     document.querySelector('#auto-skip').addEventListener('input', event => {
         autoMineSkip = +event.target.value.replace(/[A-Za-z!@#$%^&*()]/g, '').replace(/[,]/g, "");
         localStorage.setItem("autoMineSkip", autoMineSkip);
         event.target.value = autoMineSkip.toLocaleString('en-US');
     });
+    */
 
     addGlobalStyle('#threshold-input { display:flex;flex-direction:row;flex-wrap:wrap;align-content:center;justify-content:space-evenly;align-items:center; }');
-    addGlobalStyle('#skip-input { display:flex;flex-direction:row;flex-wrap:wrap;align-content:center;justify-content:space-evenly;align-items:center; }');
+    addGlobalStyle('#item-threshold-input { display:flex;flex-direction:row;flex-wrap:wrap;align-content:center;justify-content:space-evenly;align-items:center; }');
     addGlobalStyle('#small-restore { width:150px; }');
-    addGlobalStyle('#auto-skip { width:150px; }');
+    addGlobalStyle('#item-threshold { width:75px; }');
+    //addGlobalStyle('#skip-input { display:flex;flex-direction:row;flex-wrap:wrap;align-content:center;justify-content:space-evenly;align-items:center; }');
+    //addGlobalStyle('#auto-skip { width:100px; }');
 }
 
 function startAutoMine(event) {
@@ -93,7 +107,6 @@ function startAutoMine(event) {
     } else {
         clearTimeout(busyMining);
         //clearTimeout(mineComplete);
-        resetInProgress = false;
         clearInterval(autoMineTimer)
     }
     localStorage.setItem('autoMineState', mineState);
@@ -109,20 +122,34 @@ function doAutoMine() {
     const largeRestore = player.itemList["LargeRestore"]();
     const getCost = ItemList["SmallRestore"].price();
     const treasureHunting = Math.sign(treasureHunter) >= 0;
+    const treasureTypes = ['Fossils', 'Evolution Items', 'Gem Plates', 'Shards', 'Diamond Value'];
     const surveyResult = Mine.surveyResult();
-    let validTreasure;
-    if (treasureHunting) {
-        try { validTreasure = surveyResult.includes(treasureItems[treasureHunter]) }
-        catch (err) { validTreasure = null }
+    let treasureAmount;
+    if (Mine.loadingNewLayer) {
+        // Do nothing while the new layer is loading
+        return;
     }
-    if (treasureHunting && validTreasure == false && skipsRemain != 0) {
+    if (treasureHunting && surveyResult) {
+        // Parse survey for the treasure type we want
+        try {
+            const re = new RegExp(String.raw`${treasureTypes[treasureHunter]}: (\d+)`);
+            treasureAmount = +re.exec(surveyResult)[1];
+        } catch (err) {
+            treasureAmount = 0;
+        }
+    }
+    if (treasureHunting && !surveyResult) {
+        // Survey the layer
+        mineMain();
+    } else if (treasureHunting && treasureAmount < itemThreshold && skipsRemain > 0) {
+        // Too few of the desired treasure type, skip
         resetLayer();
-    } else if (validTreasure || (treasureHunting && validTreasure == null)) {
-        mineMain();
-    } else if (buriedItems >= autoMineSkip || skipsRemain == 0) {
-        mineMain();
+    } else if (!treasureHunting && buriedItems < itemThreshold && skipsRemain > 0) {
+        // Too few items, skip
+        resetLayer();
     } else {
-        resetLayer();
+        // Either the layer meets requirements or we're out of skips
+        mineMain();
     }
     if (layersMined != App.game.statistics.undergroundLayersMined()) {
         if (sellTreasureState) {
@@ -145,14 +172,18 @@ function doAutoMine() {
                 } else {
                     ItemList["SmallRestore"].use();
                 }
+                // Refresh energy count so we can use it immediately
+                getEnergy = Math.floor(App.game.underground.energy);
             }
         }
-        if (!surveyResult && treasureHunting) {
-            if (getEnergy >= 15) {
-                Mine.survey(); $('#mine-survey-result').tooltip("hide");
+        if (!surveyResult && treasureHunting && skipsRemain != 0) {
+            if (getEnergy >= App.game.underground.getSurvey_Cost()) {
+                Mine.survey(); 
+                $('#mine-survey-result').tooltip("hide");
             }
             return true;
         } else {
+            let minedThisInterval = false;
             if (getEnergy >= 1) {
                 if (Mine.toolSelected() != 0) {
                     Mine.toolSelected(Mine.Tool.Chisel);
@@ -178,38 +209,25 @@ function doAutoMine() {
                             )) {
                                 Mine.click(ti, tj);
                                 getEnergy -= 1;
+                                minedThisInterval = true;
                             }
                         }
                     }
                 }
             }
-            if (getEnergy >= 10) {
+            if (getEnergy >= 10 && !minedThisInterval) {
+                // Only bomb if out of places to chisel
                 Mine.bomb();
             }
         }
     }
 
     function resetLayer() {
-        if (!resetInProgress) {
-            if (Mine.itemsBuried() >= Mine.itemsFound()) {
-                // Don't resolve queued up calls to checkCompleted() until completed() is finished and sets loadingNewLayer to false
-                if (Mine.loadingNewLayer == true) {
-                    resetInProgress = true;
-                }
-                if (!resetInProgress) {
-                    Mine.loadingNewLayer = true;
-                    setTimeout(Mine.completed, 1500);
-                    //GameHelper.incrementObservable(App.game.statistics.undergroundLayersMined);
-                    if (Mine.skipsRemaining() != 0) {
-                        GameHelper.incrementObservable(Mine.skipsRemaining, -1);
-                    }
-                    busyMining = setTimeout(function () {
-                        resetInProgress = false;
-                    }, 1500);
-                } else {
-                    resetInProgress = false;
-                }
-            }
+        Mine.loadingNewLayer = true;
+        setTimeout(Mine.completed, 1500);
+        //GameHelper.incrementObservable(App.game.statistics.undergroundLayersMined);
+        if (Mine.skipsRemaining() > 0) {
+            GameHelper.incrementObservable(Mine.skipsRemaining, -1);
         }
     }
 }
@@ -235,16 +253,27 @@ function treasureHunt(event) {
     const value = +element.value;
     treasureHunter = value;
     localStorage.setItem('treasureHunter', value);
+    setTreasureImage();
+}
+
+function setTreasureImage() {
+    const imageSources = ['items/underground/Hard Stone.png', 'breeding/Helix Fossil.png', 'items/evolution/Fire_stone.png', 
+    'items/underground/Flame Plate.png', 'items/underground/Red Shard.png', 'currency/diamond.svg'];
+    const imageTitles = ['Item', 'Fossil', 'Evolution Stone', 'Plate', 'Shard', 'Diamond'];
+    document.getElementById('treasure-image').src = `assets/images/${imageSources[1+treasureHunter]}`;
+    document.getElementById('treasure-image').title = imageTitles[1+treasureHunter];
 }
 
 const updateCheckMine = JSON.parse(localStorage.getItem('autoMineUpdate'));
-if (!updateCheckMine || updateCheckMine != 1.6) {
+if (!updateCheckMine || updateCheckMine != SCRIPT_VERSION) {
     localStorage.setItem("autoMineState", false);
     localStorage.setItem("autoSmallRestore", false);
     localStorage.setItem("autoBuyThreshold", 0);
-    localStorage.setItem("autoMineSkip", 0);
     localStorage.setItem("autoSellTreasure", false);
-    localStorage.setItem("autoMineUpdate", 1.6);
+    localStorage.setItem("treasureHunter", -1);
+    localStorage.setItem("itemThreshold", 0);
+    localStorage.setItem("autoMineUpdate", SCRIPT_VERSION);
+    //localStorage.setItem("autoMineSkip", 0);
 }
 if (!localStorage.getItem('autoMineState')) {
     localStorage.setItem("autoMineState", false);
@@ -255,21 +284,25 @@ if (!localStorage.getItem('autoSmallRestore')) {
 if (!localStorage.getItem('autoBuyThreshold')) {
     localStorage.setItem("autoBuyThreshold", 0);
 }
-if (!localStorage.getItem('autoMineSkip')) {
-    localStorage.setItem("autoMineSkip", 0);
-}
 if (!localStorage.getItem('autoSellTreasure')) {
     localStorage.setItem("autoSellTreasure", false);
 }
 if (!localStorage.getItem('treasureHunter')) {
     localStorage.setItem("treasureHunter", -1);
 }
+if (!localStorage.getItem('itemThreshold')) {
+    localStorage.setItem("itemThreshold", 0);
+}
+/*if (!localStorage.getItem('autoMineSkip')) {
+    localStorage.setItem("autoMineSkip", 0);
+}*/
 mineState = JSON.parse(localStorage.getItem('autoMineState'));
 smallRestoreState = JSON.parse(localStorage.getItem('autoSmallRestore'));
 setThreshold = JSON.parse(localStorage.getItem('autoBuyThreshold'));
-autoMineSkip = JSON.parse(localStorage.getItem('autoMineSkip'));
+//autoMineSkip = JSON.parse(localStorage.getItem('autoMineSkip'));
 sellTreasureState = JSON.parse(localStorage.getItem('autoSellTreasure'));
 treasureHunter = JSON.parse(localStorage.getItem('treasureHunter'));
+itemThreshold = JSON.parse(localStorage.getItem('itemThreshold'));
 
 function loadScript() {
     var oldInit = Preload.hideSplashScreen

--- a/enhancedautomine.user.js
+++ b/enhancedautomine.user.js
@@ -223,11 +223,13 @@ function doAutoMine() {
     }
 
     function resetLayer() {
-        Mine.loadingNewLayer = true;
-        setTimeout(Mine.completed, 1500);
-        //GameHelper.incrementObservable(App.game.statistics.undergroundLayersMined);
-        if (Mine.skipsRemaining() > 0) {
-            GameHelper.incrementObservable(Mine.skipsRemaining, -1);
+        if (!Mine.loadingNewLayer) {
+            Mine.loadingNewLayer = true;
+            setTimeout(Mine.completed, 1500);
+            //GameHelper.incrementObservable(App.game.statistics.undergroundLayersMined);
+            if (Mine.skipsRemaining() > 0) {
+                GameHelper.incrementObservable(Mine.skipsRemaining, -1);
+            }
         }
     }
 }


### PR DESCRIPTION
-New treasure hunter setting to skip layers with too few of the desired item type
-Merged auto-skipping layers with too few items into the treasure hunter (UI got too cramped)
-Efficiency improvements to when the script surveys, bombs, and uses restores
-Simplified the reset layer code by integrating it more closely with the main game

Improves on #200, implements #132 and #99.