### PR TITLE
AutoGym Improvment

### DIFF
--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -325,7 +325,8 @@ function autoGym() {
                 //Making sure we don't fight Gyms that don't exist and fight the lowest if we pick higher
                 const selGym = Math.min(gymSelect, gymChampLen);
                 //#5 is purely for the Champion and typically E4 where there's 5 total
-                if (gymSelect == 4 && gymSelect === gymChampLen && champUnlocked) {
+                //Whatever value is selected, if it's above the # of gyms, we fight a champion if available 
+                if (gymSelect >= gymChampLen && champUnlocked) {
                     GymRunner.startGym(getChamp[0]);
                 } else if (getGyms[selGym].isUnlocked()) {
                     //Fighting the selected Gym here


### PR DESCRIPTION
Minor improvment in Champion management.
When we have a champion which is not an E4, we were not able to autofight with a numbered option (but the "ALL" option worked)
Any # selection which is higher than the number of gyms should autofight the champion if available.
Should solve #232 for Leon in Wyndon Stadium