### PR TITLE
Grab starterPKMN by comparing starterID

### DIFF
--- a/enhancedautohatchery.user.js
+++ b/enhancedautohatchery.user.js
@@ -294,8 +294,8 @@ function autoHatcher() {
             });
 
             const hasPKRS = App.game.keyItems.hasKeyItem(KeyItemType.Pokerus_virus);
-            const starterName = GameConstants.Starter[player.starter()];
-            const starterPKMN = PartyController.getSortedList().filter(p => p.name == starterName)[0];
+            const starterID = GameConstants.RegionalStarters[GameConstants.Region.kanto][player.regionStarters[GameConstants.Region.kanto]()];
+            const starterPKMN = PartyController.getSortedList().filter(p => p.id == starterID)[0];
             const virusReady = PartyController.getSortedList().filter(e => e._level() == 100 && e.breeding == false && e.pokerus == false);
             if (pkrsState && hasPKRS && virusReady.length != 0) {
                 if (starterPKMN._level() == 100 && !starterPKMN.breeding) {


### PR DESCRIPTION
Resolves #251 

Because `player.starter()` isn't available any longer, and I couldn't find a way to grab the player starter name without going through the ID first, I opted to change the definition for starterPKMN to search for the starter by ID instead of name.

`player.regionStarters[GameConstants.Region.kanto]()` returns an index value between 0 and 2 (0 and 3 for Kanto, where Pikachu can be selected as a starter). This index value can be used to retrieve the starter Pokemon ID from GameConstants.RegionalStarters, which is a 2-dimensional array containing the ids for each starter in each region.


