### PR TITLE
Catchfilterfantasia/dungeon-token-fix

### DIFF
--- a/catchfilterfantasia.user.js
+++ b/catchfilterfantasia.user.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name          [Pokeclicker] Catch Filter Fantasia
 // @namespace     Pokeclicker Scripts
-// @author        Ephenia
+// @author        Ephenia (Credit: Pastaficionado)
 // @description   An experimental catch filter that aims to help you have much better control and will completely change how you capture Pokémon.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.7
+// @version       1.8
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues

--- a/catchfilterfantasia.user.js
+++ b/catchfilterfantasia.user.js
@@ -468,11 +468,12 @@ function overideDefeatPokemon() {
             pokeBall = App.game.pokeballs.calculatePokeballToUse(enemyPokemon.id, isShiny);
         }
 
+        const route = player.town()?.dungeon?.difficultyRoute || 1;
         if (pokeBall !== GameConstants.Pokeball.None && filterState && (catchFilter.includes(enemyPokemon.id) || (filterTypes[type1] || filterTypes[type2]))) {
             this.prepareCatch(enemyPokemon, pokeBall);
             setTimeout(
                 () => {
-                    this.attemptCatch(enemyPokemon, Battle.route, player.region);
+                    this.attemptCatch(enemyPokemon, route, player.region);
                     if (DungeonRunner.defeatedBoss()) {
                         DungeonRunner.dungeonWon();
                     }
@@ -483,7 +484,7 @@ function overideDefeatPokemon() {
             this.prepareCatch(enemyPokemon, pokeBall);
             setTimeout(
                 () => {
-                    this.attemptCatch(enemyPokemon, Battle.route, player.region);
+                    this.attemptCatch(enemyPokemon, route, player.region);
                     if (DungeonRunner.defeatedBoss()) {
                         DungeonRunner.dungeonWon();
                     }


### PR DESCRIPTION
Fix for #216 and #257.

Catching in dungeons was rewarding single digit dungeon tokens for normal and boss enemies. Trainer battles were working as expected.

An undefined value was being passed as the route number into the attemptCatch method, which was translated into a zero somewhere down the call chain, resulting in a low reward. I've updated the route param to use the same logic as the base game.

Tested lightly.