### PR TITLE
Major autoclicker efficiency overhaul + new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,44 +167,47 @@ I think the rest of the buttons there are self-explanatory, and you guys can hav
 <hr>
 
 ## **Enhanced Auto Clicker** ([enhancedautoclicker.user.js](//github.com/Ephenia/Pokeclicker-Scripts/blob/master/enhancedautoclicker.user.js)) ([One-Click Install](//github.com/Ephenia/Pokeclicker-Scripts/raw/master/enhancedautoclicker.user.js))
-This script was originally created by <b>Ivan Lay</b> and [can be found over here](//github.com/ivanlay/pokeclicker-automator).
+This script is based on one originally created by <b>Ivan Lay</b>, which [can be found here](//github.com/ivanlay/pokeclicker-automator). 
 
-This script currently features quite a lot more over the old one. This enhanced version mainly adds in a button to toggle the Auto Clicker on/off without the need of a refresh. This setting will also save and persist through refresh/browser close.
+<img width="608" src="https://user-images.githubusercontent.com/12092270/229034199-21bb914c-d6c3-4d97-bc4a-4521052a2740.png">
 
-The button can be found under your currencies, as shown here:<br>
+The main Auto Clicker button can be found under your currencies. Clicking it toggles the Auto Clicker on/off without the need of a refresh. This setting will also save and persist through page refresh/close.
 
-![image](https://user-images.githubusercontent.com/26987203/139553777-6c8fbeb9-6ebf-4884-9b60-04bbc218d148.png)
+The Auto Clicker button displays various statistics while running:<br>
 
-I have also added 4 new values to the auto clicker component:<br>
+<strong>• Clicker Efficiency</strong> - How close the Auto Clicker is to its maximum speed. The closer to 100%, the better.<br>
+<strong>• Clicks/s</strong> or <strong>DPS</strong> - The number of clicks per second or click damage per second the Auto Clicker is producing.<br>
+<strong>• Req. Clicks</strong> or <strong>Req. Click Damage</strong> - The number of clicks or click attack necessary to one-shot enemies in the current route, gym, or dungeon. The color changes depending on whether you meet the requirement. This ignores dungeon boss health and health bonuses from dungeon chests.<br>
+<strong>• Enemy/s</strong> - How many enemies you are defeating per second.<br>
 
-<strong>• Auto Click DPS</strong> - This will tell you the total amount of click damage that you're dealing per second while the Auto Clicker is active.<br>
-<strong>• Req. DPS</strong> - This will tell you the total required amount of click damage (Auto Click DPS) needed for you to 1 shot the route and fully cap out the red (health) bar.<br>
-<strong>• Enemy/s</strong> - How many enemies you are defeating per second through the use of the Auto Clicker and it being currently active (20 is cap).
+You can switch between clicks and damage display modes in the settings menu. Statistics are averaged over the last ten seconds, reset upon changing locations.
 
-<strong>Auto Click DPS will always show in Gold. Required DPS will change color depending on if you meet it or not.</strong><br>
+### **Auto Gym**
 
-> <strong>As of 1.4 the Auto Gym feature has been released and is found below the Auto Click button. Some notes about how this works:</strong><br><br>
+The Auto Gym feature is found below the Auto Click button. Some notes about how this works:
+
 • Auto Gym will only work while the Auto Clicker is active.<br>
-• Auto Gym when activated will automatically fight the Gym in the town you are in or the one you visited last (if it has a Gym).<br>
-• There is a dropdown to the right of the Auto Gym button which is meant for Elite Fours. The number that you set this to will be which Elite Four member you will fight (or at least try to). So for example, if you set this to #5 then you will be fighting the Champion or at least that's what Auto Gym's priority will be. This means Auto Gym will also automatically fight through all the Elite Four preceding the one you set it to if they were undefeated previously.
+• Auto Gym when activated will automatically fight the Gym in the town you are in.<br>
+• There is a dropdown to the right of the Auto Gym button which is meant for Elite Fours and other towns with multiple gyms. The number that you set this to determines which gym or Elite Four member you will fight. For example, if you set it to #5 while at a Pokemon League, you will fight the Champion. However, if you set Auto Gym to fight a gym you have not yet unlocked, you will instead end up fighting the last unlocked gym in that town (if one exists) until you restart Auto Gym or select a different gym to fight. 
 
-<br>
+### **Auto Dungeon**
 
-> <strong>As of 1.5 the Auto Dungeon feature has been released which can be seen below the Auto Click button. Some notes about how this works:</strong><br><br>
+The Auto Dungeon feature is found below the Auto Click button. Some notes about how this works:
+
 • Auto Dungeon will only work while the Auto Clicker is active.<br>
-• Auto Dungeon when activated will automatically fight the current dungeon, the last dungeon you've visited or the dungeon in the one in the last town you were in (if it has one).<br>
-• There is a dropdown to the right of the Auto Dungeon button which contains 2 modes:<br><br>
-<strong>"F" for Farm Mode</strong> - this will run through the dungeon in its entirety and fight all the enemies as well as loot all the chests. The boss will be saved for last.<br>
-<strong>"B" for Boss Rusher</strong> - this will try to clear the dungeon as fast as possible and rush the Boss. The Boss will always be the top priority, chests will not be opened as they increase enemy hp, making clearing slower. Note that this currently does not include pathfinding, so it will only fight the Boss if it is adjecent to a visited tile.
+• Auto Dungeon when activated will automatically explore the current dungeon, or begin exploring a dungeon whose entrance you are at. 
+• There is a dropdown to the right of the Auto Dungeon button to choose between two modes:<br><br>
+<strong>"F" for Farm Mode</strong> - this runs through the dungeon in its entirety and fights all the enemies as well as loot all the chests, saving the boss for last. It now waits to open chests until right before the boss fight for faster clearing.<br/>
+<strong>"B" for Boss Rusher</strong> - this tries to clear the dungeon as fast as possible to fight the boss. Chests are not opened as they increase enemy HP, making clearing slower. If you have unlocked Flash for a dungeon, this mode will now use it to find the boss while visiting as few columns as possible. It does not include pathfinding that uses information, like the location of the boss, not visible to the player.
 
-<br>
+### **Graphics settings**
+
+The Auto Clicker now includes graphics settings for Auto Gym and Auto Dungeon to save on performance, similar to those in the Additional Visual Settings script. These settings are located along with the statistics display mode setting in the Visual Settings tab of the settings menu. These disable most gym graphics while Auto Gym is running and most dungeon graphics while Auto Dungeon is running, respectively.
 
 ```diff
 - Note: the Auto Clicker runs every 0.05 seconds.
 - Note: statistics are checked and updated every 1 second while the Auto Clicker is active.
 ```
-
-I thought that these were some neat and useful additions to add. I hope that you guys would like them as well. I spent a lot of time on these especially with creating Auto Dungeon.
 
 <hr>
 

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -705,7 +705,7 @@ function calcClickStats() {
                 elem = document.getElementById('tick-percentage');
                 var avgTicks = calcTicks.reduce((a, b) => a + b, 0) / calcTicks.length;
                 var tickFraction = avgTicks / (ticksPerSecond * actualElapsed);
-                elem.innerHTML = tickFraction.toLocaleString('en-US', {style: 'percent', maximumFractionDigits: 1} );
+                elem.innerHTML = tickFraction.toLocaleString('en-US', {style: 'percent', maximumFractionDigits: 0} );
                 elem.style.color = 'gold';
 
                 // Average clicks/damage per second

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name          [Pokeclicker] Enhanced Auto Clicker
 // @namespace     Pokeclicker Scripts
-// @author        Ephenia (Original/Credit: Ivan Lay, Novie53, andrew951, Kaias26, kevingrillet)
-// @description   Clicks through battles appropriately depending on the game state. Also, includes a toggle button to turn Auto Clicking on or off and various insightful statistics. Now also includes an automatic Gym battler as well as Auto Dungeon with different modes, as well as being able to adjust the speed at which the Auto CLicker can click at.
+// @author        Ephenia (Original/Credit: Ivan Lay, Novie53, andrew951, Kaias26, kevingrillet, Optimatum)
+// @description   Clicks through battles, with adjustable speed and a toggle button, and provides various insightful statistics. Also includes an automatic gym battler and automatic dungeon explorer with multiple pathfinding modes, now both with settings to disable graphics for performance.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       2.8
+// @version       3.0
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -18,452 +18,605 @@
 // @run-at        document-idle
 // ==/UserScript==
 
-var clickState;
-var awaitAutoClick;
+const scriptName = 'enhancedautoclicker';
+const ticksPerSecond = 20;
+// Auto Clicker
+var autoClickState = ko.observable(false);
+var autoClickMultiplier;
 var autoClickerLoop;
-var autoClickDPS;
-var clickDPS;
-var reqDPS;
-var enemySpeedRaw;
-var enemySpeed;
-var allSelectedGym = 0;
-var gymState;
-var gymSelect;
-var dungeonState;
-var dungeonSelect;
-var foundBoss = false;
-var foundBossX;
-var foundBossY;
-var delayAutoClick;
-window.testDPS = 0;
-window.defeatDPS = 0;
+// Auto Gym
+var autoGymState = ko.observable(false);
+var autoGymSelect;
+var gymList = [];
+var gymIndex;
+//var gymChanged;
+//var gymChangedNotifier = ko.observable(false);
+// Auto Dungeon
+var autoDungeonState = ko.observable(false);
+var autoDungeonMode;
+var dungeonID = 0;
+var dungeonFloor;
+var dungeonCoords;
+var dungeonBossCoords;
+var dungeonChestCoords;
+var dungeonFloorSize;
+var dungeonFlashDistance;
+var dungeonFlashCols;
+// Clicker statistics calculator
+var calculatorLoop;
+var calculatorDisplayMode;
+var calcPlayerState = -1;
+var calcPlayerLocation;
+var calcTicks;
+var calcClicks;
+var calcEnemies;
+var calcAreaHealth;
+// Visual settings
+var gymGraphicsDisabled = ko.observable(false);
+var dungeonGraphicsDisabled = ko.observable(false);
+
+
+/* Initialization */
 
 function initAutoClicker() {
     const battleView = document.getElementsByClassName('battle-view')[0];
 
     var elemAC = document.createElement("table");
     elemAC.innerHTML = `<tbody><tr><td colspan="4">
-    <button id="auto-click-start" class="btn btn-${clickState ? 'success' : 'danger'} btn-block" style="font-size:8pt;">
-    Auto Click [${clickState ? 'ON' : 'OFF'}]<br>
+    <button id="auto-click-start" class="btn btn-${autoClickState() ? 'success' : 'danger'} btn-block" style="font-size:8pt;">
+    Auto Click [${autoClickState() ? 'ON' : 'OFF'}]<br>
     <div id="auto-click-info">
-    <div id="click-DPS">Auto Click DPS:<br><div style="font-weight:bold;color:gold;">${clickDPS.toLocaleString('en-US')}</div></div>
-    <div id="req-DPS">Req. DPS:<br><div style="font-weight:bold;">0</div></div>
-    <div id="enemy-DPS">Enemy/s:<br><div style="font-weight:bold;color:black;">0</div></div>
+    <!-- calculator display will be set by resetCalculator() -->
     </div>
     </button>
-    <div id="click-delay-cont">
-    <div id="auto-click-delay-info">Click Attack Delay: ${clickDelayFixed(1000 / delayAutoClick)}/s</div>
-    <input type="range" min="1" max="50" value="${delayAutoClick}" id="auto-click-delay">
+    <div id="click-rate-cont">
+    <div id="auto-click-rate-info">Click Attack Rate: ${(ticksPerSecond * autoClickMultiplier).toLocaleString('en-US', {maximumFractionDigits: 2})}/s</div>
+    <input id="auto-click-rate" type="range" min="1" max="5" value="${autoClickMultiplier}">
     </div>
     </td></tr>
     <tr>
     <td style="width: 42%;">
-    <button id="auto-dungeon-start" class="btn btn-block btn-${dungeonState ? 'success' : 'danger'}" style="font-size: 8pt;">
-    Auto Dungeon [${dungeonState ? 'ON' : 'OFF'}]</button>
+    <button id="auto-dungeon-start" class="btn btn-block btn-${autoDungeonState() ? 'success' : 'danger'}" style="font-size: 8pt;">
+    Auto Dungeon [${autoDungeonState() ? 'ON' : 'OFF'}]</button>
     </td>
     <td>
-  <select id="dungeon-select">
+  <select id="auto-dungeon-mode">
     <option value="0">F</option>
     <option value="1">B</option>
   </select>
     </td>
     <td style="width: 40%;">
-    <button id="auto-gym-start" class="btn btn-block btn-${gymState ? 'success' : 'danger'}" style="font-size: 8pt;">
-    Auto Gym [${gymState ? 'ON' : 'OFF'}]
+    <button id="auto-gym-start" class="btn btn-block btn-${autoGymState() ? 'success' : 'danger'}" style="font-size: 8pt;">
+    Auto Gym [${autoGymState() ? 'ON' : 'OFF'}]
     </button>
     </td>
     <td>
-  <select id="gym-select">
+  <select id="auto-gym-select">
     <option value="0">#1</option>
     <option value="1">#2</option>
     <option value="2">#3</option>
     <option value="3">#4</option>
     <option value="4">#5</option>
-    <option value="5">All</option>
+    <!--<option value="100">All</option>-->
   </select>
     </td>
     </tr>
-    </tbody>`
-    battleView.before(elemAC)
-    document.getElementById('gym-select').value = gymSelect;
-    document.getElementById('dungeon-select').value = dungeonSelect;
+    </tbody>`;
+
+    battleView.before(elemAC);
+    resetCalculator(); // initializes calculator display
+
+    // Add display settings to settings menu
+    var settingsHeader = document.createElement("tr");
+    settingsHeader.innerHTML = '<th colspan="2">Auto Clicker settings</th>';
+    document.getElementById('settingsModal').querySelector('tr[data-bind*="showMuteButton"]').after(settingsHeader);
+
+    var settingsElems = [];
+    settingsElems.push(document.createElement('tr'));
+    settingsElems.at(-1).innerHTML = `<td class="p-2">
+        Auto Clicker info display mode
+        </td>
+        <td class="p-0">
+        <select id="select-calculatorDisplayMode" class="form-control">
+        <option value="0">Clicks</option>
+        <option value="1">Damage</option>
+        </select>
+        </td>`;
+    settingsElems.push(document.createElement('tr'));
+    settingsElems.at(-1).innerHTML = `<td class="p-2">
+        <label class="m-0" for="checkbox-gymGraphicsDisabled">Disable Auto Gym graphics</label>
+        </td><td class="p-2">
+        <input id="checkbox-gymGraphicsDisabled" type="checkbox">
+        </td>`;
+    settingsElems.push(document.createElement('tr'));
+    settingsElems.at(-1).innerHTML = `<td class="p-2">
+        <label class="m-0" for="checkbox-dungeonGraphicsDisabled">Disable Auto Dungeon graphics</label>
+        </td><td class="p-2">
+        <input id="checkbox-dungeonGraphicsDisabled" type="checkbox">
+        </td>`;
+
+    settingsHeader.after(...settingsElems);
+    
+    document.getElementById('auto-gym-select').value = autoGymSelect;
+    document.getElementById('auto-dungeon-mode').value = autoDungeonMode;
+    document.getElementById('select-calculatorDisplayMode').value = calculatorDisplayMode;
+    document.getElementById('checkbox-gymGraphicsDisabled').checked = gymGraphicsDisabled();
+    document.getElementById('checkbox-dungeonGraphicsDisabled').checked = dungeonGraphicsDisabled();
 
     document.getElementById('auto-click-start').addEventListener('click', () => { toggleAutoClick(); });
-    document.getElementById('auto-gym-start').addEventListener('click', event => { toggleAutoGym(event); });
-    document.getElementById('auto-dungeon-start').addEventListener('click', event => { toggleAutoDungeon(event); });
-    document.getElementById('gym-select').addEventListener('change', event => { changeSelectedGym(event); });
-    document.getElementById('dungeon-select').addEventListener('change', event => { changeSelectedDungeon(event); });
-    document.getElementById('auto-click-delay').addEventListener('change', event => { changeClickDelay(event); });
+    document.getElementById('auto-click-rate').addEventListener('change', (event) => { changeClickMultiplier(event); });
+    document.getElementById('auto-gym-start').addEventListener('click', () => { toggleAutoGym(); });
+    document.getElementById('auto-gym-select').addEventListener('change', (event) => { changeSelectedGym(event); });
+    document.getElementById('auto-dungeon-start').addEventListener('click', () => { toggleAutoDungeon(); });
+    document.getElementById('auto-dungeon-mode').addEventListener('change', (event) => { changeDungeonMode(event); });
+    document.getElementById('checkbox-gymGraphicsDisabled').addEventListener('change', (event) => { toggleAutoGymGraphics(event); } );
+    document.getElementById('checkbox-dungeonGraphicsDisabled').addEventListener('change', (event) => { toggleAutoDungeonGraphics(event); } );
+    document.getElementById('select-calculatorDisplayMode').addEventListener('change', (event) => { changeCalcDisplayMode(event); } );
 
     addGlobalStyle('#auto-click-info { display: flex;flex-direction: row;justify-content: center; }');
     addGlobalStyle('#auto-click-info > div { width: 33.3%; }');
     addGlobalStyle('#dungeonMap { padding-bottom: 9.513%; }');
-    addGlobalStyle('#click-delay-cont { display: flex; flex-direction: column; align-items: stretch;}')
+    addGlobalStyle('#click-rate-cont { display: flex; flex-direction: column; align-items: stretch;}');
 
-    if (clickState) {
+    overrideGymRunner()
+    overrideDungeonRunner();
+
+    if (autoClickState()) {
         autoClicker();
-        calcClickDPS();
     }
-    overideClickAttack();
 }
+
+function addGlobalStyle(css) {
+    var head = document.getElementsByTagName('head')[0];
+    if (!head) { return; }
+    var style = document.createElement('style');
+    style.type = 'text/css';
+    style.innerHTML = css;
+    head.appendChild(style);
+}
+
+/* Settings event handlers */
 
 function toggleAutoClick() {
     const element = document.getElementById('auto-click-start');
-    clickState = !clickState;
-    clickState ? autoClicker() : clearInterval(autoClickerLoop);
-    clickState ? calcClickDPS() : clearInterval(autoClickDPS);
-    if (clickState) {
-        clickDPS = JSON.parse(localStorage.getItem('storedClickDPS'));
-    } else {
-        clickDPS = 0;
-        reqDPS = 0;
-        enemySpeedRaw = 0;
+    autoClickState(!autoClickState());
+    localStorage.setItem('autoClickState', autoClickState());
+    autoClickState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
+    autoClicker();
+}
+
+function changeClickMultiplier(event) {
+    // TODO decide on a better range / function
+    const multiplier = +event.target.value;
+    if (Number.isInteger(multiplier) && multiplier > 0) {
+        autoClickMultiplier = multiplier;
+        localStorage.setItem("autoClickMultiplier", autoClickMultiplier);
+        var displayNum = (ticksPerSecond * autoClickMultiplier).toLocaleString('en-US', {maximumFractionDigits: 2})
+        document.getElementById('auto-click-rate-info').innerText = `Click Attack Rate: ${displayNum}/s`;
+        autoClicker();
     }
-    clickState ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
-    element.innerHTML = `Auto Click [${clickState ? 'ON' : 'OFF'}]<br>
-    <div id="auto-click-info">
-    <div id="click-DPS">Auto Click DPS:<br><div style="font-weight:bold;color:gold;">${clickDPS.toLocaleString('en-US')}</div></div>
-    <div id="req-DPS">Req. DPS:<br><div style="font-weight:bold;">0</div></div>
-    <div id="enemy-DPS">Enemy/s:<br><div style="font-weight:bold;color:black;">0</div></div>
-    </div>`
-    localStorage.setItem('autoClickState', clickState);
 }
 
-function toggleAutoGym(event) {
-    const element = event.target;
-    gymState = !gymState;
-    gymState ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
-    element.textContent = `Auto Gym [${gymState ? 'ON' : 'OFF'}]`;
-    localStorage.setItem('autoGymState', gymState);
-}
-
-function toggleAutoDungeon(event) {
-    const element = event.target;
-    dungeonState = !dungeonState;
-    dungeonState ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
-    element.textContent = `Auto Dungeon [${dungeonState ? 'ON' : 'OFF'}]`;
-    localStorage.setItem('autoDungeonState', dungeonState);
+function toggleAutoGym() {
+    const element = document.getElementById('auto-gym-start');
+    autoGymState(!autoGymState());
+    localStorage.setItem('autoGymState', autoGymState());
+    autoGymState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
+    element.textContent = `Auto Gym [${autoGymState() ? 'ON' : 'OFF'}]`;
+    if (autoClickState() && !autoGymState()) {
+        // Only break out of this script's auto restart, not the built-in one
+        GymRunner.autoRestart(false);
+    }
 }
 
 function changeSelectedGym(event) {
-    const element = event.target;
-    if (gymSelect != +element.value) {
-        gymSelect = +element.value;
-        localStorage.setItem("selectedGym", gymSelect);
+    const val = +event.target.value;
+    if ([0, 1, 2, 3, 4, 100].includes(val)) {
+        autoGymSelect = val;
+        localStorage.setItem("autoGymSelect", autoGymSelect);
+        // In case currently fighting a gym 
+        //setGymIndex(autoGymSelect);
+        //gymChanged = true;
     }
 }
 
-function changeSelectedDungeon(event) {
-    const element = event.target;
-    if (dungeonSelect != +element.value) {
-        dungeonSelect = +element.value;
-        localStorage.setItem("selectedDungeon", dungeonSelect);
+function toggleAutoDungeon() {
+    const element = document.getElementById('auto-dungeon-start');
+    autoDungeonState(!autoDungeonState());
+    localStorage.setItem('autoDungeonState', autoDungeonState());
+    autoDungeonState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
+    element.textContent = `Auto Dungeon [${autoDungeonState() ? 'ON' : 'OFF'}]`;
+}
+
+function changeDungeonMode(event) {
+    const val = +event.target.value;
+    // Extra value-has-changed check to avoid repeat pathfinding
+    if (val != autoDungeonMode && [0, 1].includes(val)) {
+        dungeonCoords = null;
+        autoDungeonMode = val;
+        localStorage.setItem("autoDungeonMode", autoDungeonMode);
     }
 }
 
-function getRandomInt(max) {
-    return Math.floor(Math.random() * max);
+function toggleAutoGymGraphics(event) {
+    gymGraphicsDisabled(event.target.checked);
+    localStorage.setItem('gymGraphicsDisabled', gymGraphicsDisabled());
 }
 
-function calcClickDPS() {
-    autoClickDPS = setInterval(function () {
-        const clickSec = window.testDPS;
-        let enemyHealth;
-        try {
-            enemyHealth = Battle.enemyPokemon().maxHealth();
-        }
-        catch (err) {
-            enemyHealth = 0;
-        }
-        if (clickDPS != App.game.party.calculateClickAttack() * clickSec) {
-            clickDPS = App.game.party.calculateClickAttack() * clickSec;
-            document.getElementById('click-DPS').innerHTML = `Auto Click DPS:<br><div style="font-weight:bold;color:gold;">${Math.floor(clickDPS).toLocaleString('en-US')}</div>`
-            localStorage.setItem('storedClickDPS', clickDPS)
-        }
-        if (reqDPS != enemyHealth * clickSec) {
-            reqDPS = enemyHealth * clickSec;
-            document.getElementById('req-DPS').innerHTML = `Req. DPS:<br><div style="font-weight:bold;color: ${clickDPS >= reqDPS ? 'greenyellow' : 'darkred'}">${Math.ceil(reqDPS).toLocaleString('en-US')}</div>`
-        }
-        if (enemySpeedRaw != ((App.game.party.calculateClickAttack() * clickSec) / enemyHealth).toFixed(1)) {
-            enemySpeed = ((App.game.party.calculateClickAttack() * clickSec) / enemyHealth);
-            enemySpeedRaw = enemySpeed;
-            if (isNaN(enemySpeedRaw) || enemySpeedRaw == 'Infinity' || Battle.catching()) {
-                enemySpeed = 0;
-            }
-            if (enemySpeedRaw >= clickSec && enemySpeedRaw != 'Infinity' && !Battle.catching()) {
-                enemySpeed = window.defeatDPS;
-            }
-            if (!Number.isInteger(enemySpeed) && enemySpeed != 0) { enemySpeed = enemySpeed.toFixed(1).toString().replace('.0', '') }
-            document.getElementById('enemy-DPS').innerHTML = `Enemy/s:<br><div style="font-weight:bold;color:black;">${enemySpeed}</div>`
-        }
-        window.testDPS = 0;
-        window.defeatDPS = 0;
-    }, 1000);
+function toggleAutoDungeonGraphics(event) {
+    dungeonGraphicsDisabled(event.target.checked);
+    localStorage.setItem('dungeonGraphicsDisabled', dungeonGraphicsDisabled());
 }
 
+function changeCalcDisplayMode(event) {
+    const val = +event.target.value;
+    if (val != calculatorDisplayMode && [0, 1].includes(val)) {
+        calculatorDisplayMode = val;
+        localStorage.setItem('calculatorDisplayMode', calculatorDisplayMode);
+        resetCalculator();
+    }
+}
+
+/* Auto Clicker */
+
+/**
+ * Resets and, if enabled, restarts autoclicker
+ * -While enabled, clicks <ticksPerSecond> times per second in active battle
+ * -Outside battles, runs Auto Dungeon and Auto Gym
+ */
 function autoClicker() {
-    autoClickerLoop = setInterval(function () {
-        // Click while in a normal battle
-        if (App.game.gameState == GameConstants.GameState.fighting) {
-            Battle.clickAttack();
-        }
-
-        //Auto Gym checking
-        if (gymState) {
-            autoGym();
-        }
-
-        //Auto Dungeon checking
-        if (dungeonState && DungeonRunner.fighting() == false && DungeonBattle.catching() == false) {
-            autoDungeon();
-        }
-        //Reset the values for the boss coordinates if we timeout or turn off autoDungeon
-        if ((!dungeonState && foundBoss) || (dungeonState && DungeonRunner.dungeonFinished() && foundBoss)) {
-            foundBoss = false
-            bossCoords.length = 0
-        }
-
-        // Click while in a gym battle
-        if (App.game.gameState === GameConstants.GameState.gym) {
-            GymBattle.clickAttack();
-        }
-
-        // Click while in "Tomporary Battle" (battle ultra wormhole)
-        if (App.game.gameState === GameConstants.GameState.temporaryBattle) {
-            TemporaryBattleBattle.clickAttack();
-        }
-
-        // Click while in a dungeon - will also interact with non-battle tiles (e.g. chests)
-        if (App.game.gameState === GameConstants.GameState.dungeon) {
-            if (DungeonRunner.fighting() && !DungeonBattle.catching()) {
-                DungeonBattle.clickAttack();
+    var delay = Math.ceil(1000 / ticksPerSecond);
+    clearInterval(autoClickerLoop);
+    // Restart stats calculator
+    calcClickStats(); 
+    // Only use click multiplier while autoclicking
+    overrideClickAttack(autoClickState() ? autoClickMultiplier : 1);
+    if (autoClickState()) {
+        // Start autoclicker loop
+        autoClickerLoop = setInterval(function () {
+            // Click while in a normal battle
+            if (App.game.gameState === GameConstants.GameState.fighting) {
+                Battle.clickAttack(autoClickMultiplier);
             }
+            // ...or gym battle
+            else if (App.game.gameState === GameConstants.GameState.gym) {
+                GymBattle.clickAttack(autoClickMultiplier);
+            }
+            // ...or dungeon battle
+            else if (App.game.gameState === GameConstants.GameState.dungeon && DungeonRunner.fighting()) {
+                DungeonBattle.clickAttack(autoClickMultiplier);
+            }
+            // ...or temporary battle
+            else if (App.game.gameState === GameConstants.GameState.temporaryBattle) {
+                TemporaryBattleBattle.clickAttack(autoClickMultiplier);
+            }
+            // If not battling, progress through dungeon
+            else if (autoDungeonState()) {
+                autoDungeon();
+            }
+            // If not battling gym, start battling
+            else if (autoGymState()) {
+                autoGym();
+            }
+            calcTicks[0]++;
+        }, delay);
+    } else {
+        if (autoGymState()) {
+            GymRunner.autoRestart(false);
         }
-    }, delayAutoClick); // The app hard-caps click attacks at 50
-}
-
-function changeClickDelay(event) {
-    const delay = +event.target.value;
-    delayAutoClick = delay;
-    localStorage.setItem("delayAutoClick", delay);
-    overideClickAttack();
-    if (clickState) {
-        clearInterval(autoClickerLoop);
-        autoClicker();
     }
-    let clickSec = (1000 / delayAutoClick);
-    document.getElementById('auto-click-delay-info').innerText = `Click Attack Delay: ${clickDelayFixed(clickSec)}/s`;
 }
 
-function clickDelayFixed(int) {
-    if (int != parseInt(int)) { int = int.toFixed(2) }
-    return int;
-}
-
-function overideClickAttack() {
-    // Overiding the game's function for Click Attack
+/**
+ * Override the game's function for Click Attack to:
+ * - make multiple clicks at once via multiplier
+ * - support changing the attack speed cap for higher tick speeds
+ */
+function overrideClickAttack(clickMultiplier = 1) {
+    // Set delay based on the autoclicker's tick rate
+    // (minus 1 ms to avoid rounding issues)
+    var delay = Math.min(Math.ceil(1000 / ticksPerSecond) - 1, 50);
     Battle.clickAttack = function () {
         // click attacks disabled and we already beat the starter
-        if (App.game.challenges.list.disableClickAttack.active() && player.starter() != GameConstants.Starter.None) {
+        if (App.game.challenges.list.disableClickAttack.active() && player.regionStarters[GameConstants.Region.kanto]() != GameConstants.Starter.None) {
             return;
         }
-        // TODO: figure out a better way of handling this
-        // Limit click attack speed, Only allow 1 attack per 50ms (20 per second)
         const now = Date.now();
-        if (this.lastClickAttack > now - delayAutoClick) {
+        if (this.lastClickAttack > now - delay) {
             return;
         }
         this.lastClickAttack = now;
         if (!this.enemyPokemon()?.isAlive()) {
             return;
         }
-        GameHelper.incrementObservable(App.game.statistics.clickAttacks);
-        this.enemyPokemon().damage(App.game.party.calculateClickAttack(true));
-        window.testDPS++;
+        // Don't autoclick more than needed for lethal
+        var clickDamage = App.game.party.calculateClickAttack(true);
+        var clicks = Math.min(clickMultiplier, Math.ceil(this.enemyPokemon().health() / clickDamage));
+        GameHelper.incrementObservable(App.game.statistics.clickAttacks, clicks);
+        this.enemyPokemon().damage(clickDamage * clicks);
         if (!this.enemyPokemon().isAlive()) {
             this.defeatPokemon();
-            window.defeatDPS++;
         }
     }
 }
 
+
+/* Auto Gym */
+
+/**
+ * Starts selected gym with auto restart enabled
+ */
 function autoGym() {
-    //Checking if Gyms exist here and grabbing them
-    const getGyms = player.town().content.filter((c) => ['Gym'].includes(c.constructor.name));
-    if (getGyms.length != 0) {
-        const townName = player.town().name;
-        if (!MapHelper.isTownCurrentLocation(townName)) {
-            MapHelper.moveToTown(townName)
+    if (App.game.gameState === GameConstants.GameState.town) {
+        // Find all unlocked gyms in the current town
+        gymList = player.town().content.filter((c) => (c.constructor.name == "Gym" && c.isUnlocked()));
+        if (gymList.length > 0) {
+            setGymIndex(autoGymSelect);
+            // Start in auto restart mode
+            GymRunner.startGym(gymList[gymIndex], true);
+            return;
         }
-        /*Don't think this can ever happen
-            if (player.region != player.town().region) {
-                player.region = player.town().region
-            }*/
+    }
+    // Disable if we aren't in a location with unlocked gyms
+    toggleAutoGym();
+}
 
-        if (App.game.gameState != GameConstants.GameState.gym) {
-            //Checking if Champion exists here and grabbing them
-            const getChamp = player.town().content.filter((c) => ['Champion'].includes(c.constructor.name));
-            const gymChampLen = (getGyms.length + getChamp.length) - 1;
-            //Checking if Champion is unlocked
-            let champUnlocked;
-            try { champUnlocked = getChamp[0].isUnlocked() } catch (err) { champUnlocked = false };
-            //If "All" is selected we attempt to fight and loop through all Gyms, including the Champion if available and unlocked
-            if (gymSelect === 5) {
-                //Reset if exceeded
-                if (allSelectedGym === 5 || allSelectedGym > gymChampLen) {
-                    allSelectedGym = 0;
-                }
-                if (champUnlocked && allSelectedGym === gymChampLen) {
-                    //We fight the Champion if Champion exists and is unlocked
-                    GymRunner.startGym(getChamp[0]);
-                } else if (getGyms[allSelectedGym].isUnlocked()) {
-                    //We fight Gyms instead if they're unlocked
-                    GymRunner.startGym(getGyms[allSelectedGym]);
-                }
-                allSelectedGym++;
-            } else {
-                //Making sure we don't fight Gyms that don't exist and fight the lowest if we pick higher
-                const selGym = Math.min(gymSelect, gymChampLen);
-                //#5 is purely for the Champion and typically E4 where there's 5 total
-                //Whatever value is selected, if it's above the # of gyms, we fight a champion if available 
-                if (gymSelect >= gymChampLen && champUnlocked) {
-                    GymRunner.startGym(getChamp[0]);
-                } else if (getGyms[selGym].isUnlocked()) {
-                    //Fighting the selected Gym here
-                    GymRunner.startGym(getGyms[selGym])
-                }
+/**
+ * Sets gymIndex for starting or changing gyms
+ */
+function setGymIndex(select) {
+    /*if (select == 100) {
+        // All gyms mode
+        gymIndex = 0;
+    } else { */
+        gymIndex = Math.min(select, gymList.length - 1);
+    //}
+}
+
+/**
+ * Override GymRunner built-in functions:
+ * -Add auto gym equivalent of gymWon() to save on performance by not loading town between
+ */
+function overrideGymRunner() {
+    // Necessary to support gym-cycling mode
+    /*const oldInit = GymRunner.startGym.bind(GymRunner);
+    GymRunner.startGym = function (...args) {
+        var returnVal = oldInit(...args);
+        if (GymRunner.initialRun || gymChanged) {
+            gymChangedNotifier.notifySubscribers(true);
+            gymChanged = false;
+        }
+        return returnVal;
+    }*/
+
+    GymRunner.gymWonNormal = GymRunner.gymWon;
+    // Version with free auto restart
+    GymRunner.gymWonAuto = function(gym) {
+        if (GymRunner.running()) {
+            GymRunner.running(false);
+            // First time defeating this gym
+            if (!App.game.badgeCase.hasBadge(gym.badgeReward)) {
+                gym.firstWinReward();
             }
+            GameHelper.incrementObservable(App.game.statistics.gymsDefeated[GameConstants.getGymIndex(gym.town)]);
+            // Award money for defeating gym as we're auto clicking
+            App.game.wallet.gainMoney(gym.moneyReward);
+
+            // Auto restart if we've already checked for unlocked gyms
+            if (GymRunner.autoRestart() && gymList.length > 0) {
+                // All gyms mode
+                /*
+                if (autoGymSelect == 100 && gymList.length > 1) {
+                    // Cycle through gyms
+                    gymIndex = (gymIndex + 1) % gymList.length;
+                    gymChanged = true;
+                }*/
+                // Unlike the original function, autoclicker doesn't charge the player money
+                GymRunner.startGym(gymList[gymIndex], GymRunner.autoRestart(), false);
+                return;
+            }
+
+            // Send the player back to the town they were in
+            player.town(gym.parent);
+            App.game.gameState = GameConstants.GameState.town;
+        }
+    }
+    // Only use our version when auto gym is running
+    GymRunner.gymWon = function(...args) {
+        if (autoClickState() && autoGymState()) {
+            GymRunner.gymWonAuto(...args);
+        } else {
+            GymRunner.gymWonNormal(...args);
         }
     }
 }
 
-var bossCoords = []
+/* Auto Dungeon */
 
-function autoDungeon() {
-    //Rewrite
-    if (player.town().hasOwnProperty("dungeon") == true && player.town().dungeon !== undefined) {
-        var getTokens = App.game.wallet.currencies[GameConstants.Currency.dungeonToken]();
-        var dungeonCost = player.town().dungeon.tokenCost;
-        const townName = player.town().name;
-        if (!MapHelper.isTownCurrentLocation(townName)) {
-            MapHelper.moveToTown(townName)
+/**
+ * Automatically begins and progresses through dungeons with multiple pathfinding options
+ */
+function autoDungeon() { // TODO more thoroughly test switching between modes and enabling/disabling within a dungeon
+    // Progress through dungeon
+    if (App.game.gameState === GameConstants.GameState.dungeon) {
+        if (DungeonBattle.catching()) {
+            return;
         }
-        //Don't think this condition is ever possible
-        /*if (player.region != player.town().region) {
-            player.region = player.town().region
-        }*/
-        if (getTokens >= dungeonCost && App.game.gameState != GameConstants.GameState.dungeon) {
-            DungeonRunner.initializeDungeon(player.town().dungeon)
+        // Scan each new dungeon floor
+        if (dungeonID !== DungeonRunner.dungeonID || dungeonFloor !== DungeonRunner.map.playerPosition().floor) {
+            dungeonID = DungeonRunner.dungeonID;
+            dungeonCoords = null;
+            scan();
         }
-
-        if (App.game.gameState === GameConstants.GameState.dungeon) {
-            var dungeonBoard = DungeonRunner.map.board()[DungeonRunner.map.playerPosition().floor];
-            //The boss can be found at any time
-            if (foundBoss == false) {
-                bossCoords = scan(dungeonBoard)
-            }
-            //Wander around until we can move to the boss tile
-            //Pathfinding should be implemented here, A* looks like the best algorithm
-            else if (foundBoss == true && dungeonSelect == 1) {
-                wander(dungeonBoard, bossCoords)
-            }
-            else if (dungeonSelect == 0) {
-                fullClear(dungeonBoard, bossCoords)
-            }
+        // Reset pathfinding coordinates to entrance
+        if (dungeonCoords == null) {
+            dungeonCoords = new Point(Math.floor(dungeonFloorSize / 2), dungeonFloorSize - 1);
         }
+        // Explore using selected mode
+        if (autoDungeonMode == 0) {
+            fullClear();
+        } else if (autoDungeonMode == 1) {
+            seekBoss();
+        }
+    }
+    // Begin dungeon
+    else if (App.game.gameState === GameConstants.GameState.town) {
+        if (player.town() instanceof DungeonTown) {
+            const dungeon = player.town().dungeon;
+            // Enter dungeon if unlocked and affordable
+            if (dungeon?.isUnlocked() && App.game.wallet.hasAmount(new Amount(dungeon.tokenCost, GameConstants.Currency.dungeonToken))) {
+                DungeonRunner.initializeDungeon(dungeon);
+                return;
+            } 
+        }
+        // Disable if locked, can't afford entry cost, or there's no dungeon here
+        toggleAutoDungeon();
     }
 }
 
-function scan(dungeonBoard) {
-    /*var bossCoords = []
-    var playerCoords = []*/
-    for (var i = 0; i < dungeonBoard.length; i++) {
-        for (var j = 0; j < dungeonBoard[i].length; j++) {
-            if (dungeonBoard[i][j].type() == GameConstants.DungeonTile.boss || dungeonBoard[i][j].type() == GameConstants.DungeonTile.ladder) {
-                foundBoss = true
-                return [i, j]
+/**
+ * Scans current dungeon floor for relevant locations and pathfinding data 
+ */
+function scan() {
+    var dungeonBoard = DungeonRunner.map.board()[DungeonRunner.map.playerPosition().floor];
+    dungeonFloor = DungeonRunner.map.playerPosition().floor;
+    dungeonFloorSize = DungeonRunner.map.floorSizes[DungeonRunner.map.playerPosition().floor];
+    dungeonChestCoords = [];
+    // Scan for chest and boss coordinates
+    for (var y = 0; y < dungeonBoard.length; y++) {
+        for (var x = 0; x < dungeonBoard[y].length; x++) {
+            if (dungeonBoard[y][x].type() == GameConstants.DungeonTile.chest) {
+                dungeonChestCoords.push(new Point(x,y));
             }
-            //Required for pathfinding, if ever implemented
-            /*if (dungeonBoard[i][j].hasPlayer == true){
-                playerCoords = [i, j]
-            }*/
+            if (dungeonBoard[y][x].type() == GameConstants.DungeonTile.boss || dungeonBoard[y][x].type() == GameConstants.DungeonTile.ladder) {
+                dungeonBossCoords = new Point(x,y);
+            }
         }
+    }
+    // TODO find a more future-proof way to get flash distance
+    dungeonFlashDistance = DungeonRunner.map.flash?.playerOffset[0] ?? 0;
+    dungeonFlashCols = [];
+    // Calculate minimum columns to fully reveal dungeon with Flash
+    if (dungeonFlashDistance > 0) {
+        var i = 0;
+        var j = dungeonFloorSize - 1;
+        while (i <= j) {
+            dungeonFlashCols.push(Math.min(i + dungeonFlashDistance, j));
+            if (i + dungeonFlashDistance < j - dungeonFlashDistance) {
+                dungeonFlashCols.push(j - dungeonFlashDistance);
+            }
+            i += dungeonFlashDistance * 2 + 1;
+            j -= dungeonFlashDistance * 2 + 1;
+        }
+        dungeonFlashCols.sort((a, b) => (a - b));
     }
 }
 
-function wander(dungeonBoard, bossCoords) {
-    var moves = []
-    //Attempt to move to the boss if the coordinates are within movable range
-    DungeonRunner.map.moveToCoordinates(bossCoords[1], bossCoords[0])
+/**
+ * Navigate to the boss and fight it as quickly as possible, using only info visible to the player
+ */
+function seekBoss() {
+    // Seek the boss
+    while (!(dungeonCoords.x == dungeonBossCoords.x && dungeonCoords.y == dungeonBossCoords.y)) {
+        // Boss tile not visible, cover ground
+        if (!DungeonRunner.map.board()[dungeonFloor][dungeonBossCoords.y][dungeonBossCoords.x].isVisible) {
+            // End of column, move to new column
+            if (dungeonCoords.y == 0) {
+                dungeonCoords.y = dungeonFloorSize - 1;
+                if (dungeonCoords.x >= (dungeonFloorSize - 1) - dungeonFlashDistance) {
+                    // Done with this side, move to other side of the entrance
+                    dungeonCoords.x = Math.floor(dungeonFloorSize / 2) - 1;
+                } else {
+                    // Move away from the entrance
+                    dungeonCoords.x += (dungeonCoords.x >= Math.floor(dungeonFloorSize / 2) ? 1 : -1);
+                }
+            // Dungeon has Flash unlocked
+            } else if (dungeonCoords.y == (dungeonFloorSize - 1) && dungeonFlashDistance > 0) {
+                // Skip columns not in optimal flash pathing
+                if (dungeonFlashCols.includes(dungeonCoords.x)) {
+                    dungeonCoords.y -= 1;
+                } else {
+                    // Move away from the entrance
+                    dungeonCoords.x += (dungeonCoords.x >= Math.floor(dungeonFloorSize / 2) ? 1 : -1);
+                }
+            }
+            // Move through column
+            else {
+                dungeonCoords.y -= 1;
+            }
+        }
+        // Boss visible, move towards it
+        else if (dungeonCoords.y != dungeonBossCoords.y) {
+            dungeonCoords.y += (dungeonCoords.y < dungeonBossCoords.y ? 1 : -1);
+        }
+        else if (dungeonCoords.x != dungeonBossCoords.x) {
+            dungeonCoords.x += (dungeonCoords.x < dungeonBossCoords.x ? 1 : -1);
+        }
+        // One move per tick to look more natural
+        if (!DungeonRunner.map.board()[dungeonFloor][dungeonCoords.y][dungeonCoords.x].isVisited) {
+            DungeonRunner.map.moveToCoordinates(dungeonCoords.x, dungeonCoords.y);
+            return; 
+        }
+    }
+    // Start boss / move floors
+    DungeonRunner.map.moveToCoordinates(dungeonBossCoords.x, dungeonBossCoords.y);
     if (DungeonRunner.map.currentTile().type() == GameConstants.DungeonTile.boss) {
-        foundBoss = false
-        bossCoords.length = 0
-        DungeonRunner.startBossFight()
+        DungeonRunner.startBossFight();
+    } else if (DungeonRunner.map.currentTile().type() == GameConstants.DungeonTile.ladder) {
+        DungeonRunner.nextFloor();
     }
-    if (DungeonRunner.map.currentTile().type() == GameConstants.DungeonTile.ladder) {
-        foundBoss = false
-        bossCoords.length = 0
-        DungeonRunner.nextFloor()
-    }
-    //Iterates through the board and compiles all possible moves
-    for (var i = 0; i < dungeonBoard.length; i++) {
-        for (var j = 0; j < dungeonBoard[i].length; j++) {
-            //The entrance doesn't count as visited on first entering a dungeon so this OR is required
-            if (dungeonBoard[i][j].isVisited == true || dungeonBoard[i][j].type() == GameConstants.DungeonTile.entrance) {
-                //This is required because if the column doesn't exist it throws an attribute of undefined error
-                if (dungeonBoard[i + 1] != undefined) {
-                    if (dungeonBoard[i + 1][j] != undefined) {
-                        if (dungeonBoard[i + 1][j].isVisited == false) moves.push([i + 1, j])
-                    }
-                }
-                if (dungeonBoard[i - 1] != undefined) {
-                    if (dungeonBoard[i - 1][j] != undefined) {
-                        if (dungeonBoard[i - 1][j].isVisited == false) moves.push([i - 1, j])
-                    }
-                }
-                if (dungeonBoard[i][j + 1] != undefined) {
-                    if (dungeonBoard[i][j + 1].isVisited == false) moves.push([i, j + 1])
-                }
-                if (dungeonBoard[i][j - 1] != undefined) {
-                    if (dungeonBoard[i][j - 1].isVisited == false) moves.push([i, j - 1])
-                }
-            }
-        }
-    }
-    //Select a random move from compiled list of possible ones
-    var moveTo = moves[getRandomInt(moves.length)]
-    //Coordinates saved in couples of [y, x] so we swap them when we want to move
-    DungeonRunner.map.moveToCoordinates(moveTo[1], moveTo[0])
-    //Reset moves array
-    moves.length = 0
 }
 
-function fullClear(dungeonBoard, bossCoords) {
-    //Get number of invisible tiles, if 0 we have the map
-    const invisTile = document.getElementById('dungeonMap').querySelectorAll('.tile-invisible').length;
-    //Chests
-    const getChests = document.getElementById('dungeonMap').querySelectorAll('.tile-chest').length;
-    //Enemies
-    const getEnemy = document.getElementById('dungeonMap').querySelectorAll('.tile-enemy').length;
-
-    for (var i = 0; i < dungeonBoard.length; i++) {
-        for (var j = 0; j < dungeonBoard[i].length; j++) {
-            //Basically just attempts to move to all tiles that aren't cleared
-            if (dungeonBoard[i][j].isVisited == false) {
-                DungeonRunner.map.moveToCoordinates(j, i);
+/**
+ * Fully explores dungeon, opening all chests at end of each floor
+ */
+function fullClear() {
+    // Fully explore floor
+    while (dungeonCoords !== -1) {
+        // Handles the segment to the right of the entrance
+        if ((dungeonCoords.y == dungeonFloorSize - 1) && dungeonCoords.x >= Math.floor(dungeonFloorSize / 2)) {
+            if (dungeonCoords.x == dungeonFloorSize - 1) {
+                dungeonCoords.x = Math.floor(dungeonFloorSize / 2) - 1;
+            } else {
+                dungeonCoords.x += 1;
             }
-
-            if (DungeonRunner.map.currentTile().type() == GameConstants.DungeonTile.chest) {
-                DungeonRunner.openChest();
+        } 
+        // Move in one direction until reaching the wall
+        else {
+            var direction = (-1) ** (dungeonFloorSize - dungeonCoords.y);
+            // End of row, move up one
+            if ((dungeonCoords.x == (dungeonFloorSize - 1) && direction > 0) || 
+                (dungeonCoords.x == 0 && direction < 0)) {
+                if (dungeonCoords.y == 0) {
+                    // Floor fully explored
+                    dungeonCoords = -1;
+                    break;
+                } else {
+                    dungeonCoords.y -= 1;
+                }
+            } else {
+                dungeonCoords.x += direction;
             }
         }
+        // One move per tick to look more natural
+        if (!DungeonRunner.map.board()[dungeonFloor][dungeonCoords.y][dungeonCoords.x].isVisited) {
+            DungeonRunner.map.moveToCoordinates(dungeonCoords.x, dungeonCoords.y);
+            return; 
+        }
+        // Just in case changed to allow multiple moves per tick
+        else if (DungeonRunner.fighting() || DungeonBattle.catching()) {
+            return;
+        }
     }
-    //If we cleared the entire floor, move to the boss room and start the fight
-    if (invisTile == 0 && getChests == 0 && getEnemy == 0 && foundBoss == true) {
-        DungeonRunner.map.moveToCoordinates(bossCoords[1], bossCoords[0]);
-        foundBoss = false;
-        bossCoords.length = 0;
-
+    // Floor explored, open chests
+    if (dungeonChestCoords.length > 0) {
+        var chest = dungeonChestCoords.pop();
+        DungeonRunner.map.moveToCoordinates(chest.x, chest.y);
+        DungeonRunner.openChest();
+    }
+    // Boss / ladder time
+    else {
+        DungeonRunner.map.moveToCoordinates(dungeonBossCoords.x, dungeonBossCoords.y);
         if (DungeonRunner.map.currentTile().type() == GameConstants.DungeonTile.boss) {
             DungeonRunner.startBossFight();
         } else if (DungeonRunner.map.currentTile().type() == GameConstants.DungeonTile.ladder) {
@@ -472,90 +625,354 @@ function fullClear(dungeonBoard, bossCoords) {
     }
 }
 
-if (!validParse(localStorage.getItem('autoClickState'))) {
-    localStorage.setItem("autoClickState", false);
-}
-if (!validParse(localStorage.getItem('storedClickDPS'))) {
-    localStorage.setItem("storedClickDPS", 0);
-}
-if (!validParse(localStorage.getItem('autoGymState'))) {
-    localStorage.setItem("autoGymState", false);
-}
-if (!validParse(localStorage.getItem('selectedGym'))) {
-    localStorage.setItem("selectedGym", 0);
-}
-if (!validParse(localStorage.getItem('autoDungeonState'))) {
-    localStorage.setItem("autoDungeonState", false);
-}
-if (!validParse(localStorage.getItem('selectedDungeon'))) {
-    localStorage.setItem("selectedDungeon", 0);
-}
-if (!validParse(localStorage.getItem('delayAutoClick'))) {
-    localStorage.setItem("delayAutoClick", 50);
-}
-clickState = JSON.parse(localStorage.getItem('autoClickState'));
-gymState = JSON.parse(localStorage.getItem('autoGymState'));
-gymSelect = JSON.parse(localStorage.getItem('selectedGym'));
+/**
+ * Override DungeonRunner built-in functions:
+ * -Add dungeon ID tracking to initializeDungeon() for easier mapping
+ * -Add auto dungeon equivalent of dungeonWon() to save on performance by restarting without loading town
+ */
+function overrideDungeonRunner() {
+    // Differentiate between dungeons for mapping
+    DungeonRunner.dungeonID = 0;
+    const oldInit = DungeonRunner.initializeDungeon.bind(DungeonRunner);
+    DungeonRunner.initializeDungeon = function (...args) {
+        DungeonRunner.dungeonID++;
+        return oldInit(...args);
+    }
 
-try {
-    dungeonState = JSON.parse(localStorage.getItem('autoDungeonState'));
-} catch (error) {
-    dungeonState = false
-    localStorage.setItem("autoDungeonState", false);
-}
+    DungeonRunner.dungeonWonNormal = DungeonRunner.dungeonWon;
+    // Version with integrated auto-restart to avoid loading town in between dungeons
+    DungeonRunner.dungeonWonAuto = function () {
+        if (!DungeonRunner.dungeonFinished()) {
+            DungeonRunner.dungeonFinished(true);
+            // First time clearing dungeon
+            if (!App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]()) {
+                DungeonRunner.dungeon.rewardFunction();
+            }
+            GameHelper.incrementObservable(App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]);
 
-dungeonSelect = JSON.parse(localStorage.getItem('selectedDungeon'));
-delayAutoClick = JSON.parse(localStorage.getItem('delayAutoClick'));
-clickDPS = clickState ? JSON.parse(localStorage.getItem('storedClickDPS')) : 0;
+            // Auto restart dungeon
+            if (DungeonRunner.hasEnoughTokens()) {
+                // Clear old board to force map visuals refresh
+                DungeonRunner.map.board([]);
+                DungeonRunner.initializeDungeon(DungeonRunner.dungeon);
+                return;
+            }
 
-function loadScript() {
-    var oldInit = Preload.hideSplashScreen
-
-    Preload.hideSplashScreen = function () {
-        var result = oldInit.apply(this, arguments)
-        initAutoClicker()
-        return result
+            MapHelper.moveToTown(DungeonRunner.dungeon.name);
+        }
+    }
+    // Only use our version when auto dungeon is running
+    DungeonRunner.dungeonWon = function (...args) {
+        if (autoClickState() && autoDungeonState()) {
+            DungeonRunner.dungeonWonAuto(...args);
+        } else {
+            DungeonRunner.dungeonWonNormal(...args); 
+        }
     }
 }
 
-var scriptName = 'enhancedautoclicker'
+/* Clicker statistics calculator */
+
+/**
+ * Resets and, if auto clicker is running, restarts calculator
+ * Shows the following statistics, averaged over the last ten seconds:
+ * -Percentage of ticksPerSecond the autoclicker is actually executing
+ * -Clicks per second or damage per second, depending on display mode
+ * -Required number of clicks or click attack damage to one-shot the current location, depending on display mode
+ * --Ignores dungeon bosses and chest health increases
+ * -Enemies defeated per second
+ * Statistics are reset when the player changes locations
+ */
+function calcClickStats() {
+    clearInterval(calculatorLoop);
+    resetCalculator();
+    if (autoClickState()) {
+        calculatorLoop = setInterval(function () {
+            if (!hasPlayerMoved()) {
+                var elem;
+                var clickDamage = App.game.party.calculateClickAttack(true);
+                
+                // Percentage of maximum ticksPerSecond 
+                elem = document.getElementById('tick-percentage');
+                var avgTicks = calcTicks.reduce((a, b) => a + b, 0) / calcTicks.length;
+                avgTicks = Math.round((avgTicks / ticksPerSecond) * 100) / 100; // round to integer percentage point
+                avgTicks = avgTicks.toLocaleString('en-US', {style: 'percent', maximumFractionDigits: 1} );
+                elem.innerHTML = avgTicks;
+                elem.style.color = 'gold';
+
+                // Average clicks/damage per second
+                elem = document.getElementById('clicks-per-second');
+                var avgClicks = (App.game.statistics.clickAttacks() - calcClicks.at(-1)) / calcClicks.length;
+                if (calculatorDisplayMode == 1) {
+                    // display damage mode
+                    var avgDPS = avgClicks * clickDamage;
+                    elem.innerHTML = avgDPS.toLocaleString('en-US', {maximumFractionDigits: 0});
+                    elem.style.color = 'gold';
+                } else {
+                    // display clicks mode
+                    elem.innerHTML = avgClicks.toLocaleString('en-US', {maximumFractionDigits: 1});
+                    elem.style.color = 'gold';
+                }
+
+                // Required clicks/click damage
+                elem = document.getElementById('req-clicks');
+                if (calculatorDisplayMode == 1) {
+                    // display damage mode
+                    var reqDamage = calcAreaHealth;
+                    elem.innerHTML = reqDamage.toLocaleString('en-US');
+                    elem.style.color = (clickDamage >= reqDamage ? 'greenyellow' : 'darkred');
+                } else {
+                    // display clicks mode
+                    var reqClicks = Math.max((calcAreaHealth / clickDamage), 1);
+                    reqClicks = Math.ceil(reqClicks * 10) / 10; // round up to one decimal point
+                    elem.innerHTML = reqClicks.toLocaleString('en-US', {maximumFractionDigits: 1});
+                    elem.style.color = (reqClicks == 1 ? 'greenyellow' : 'darkred');
+                }
+
+                // Enemies per second
+                elem = document.getElementById('enemies-per-second')
+                var avgEnemies = (App.game.statistics.totalPokemonDefeated() - calcEnemies.at(-1)) / calcEnemies.length;
+                elem.innerHTML = avgEnemies.toLocaleString('en-US', {maximumFractionDigits: 1});
+                
+                // Make room for next second's stats tracking
+                // Add new entries to start of array for easier incrementing
+                calcTicks.unshift(0);
+                if (calcTicks.length > 10) {
+                    calcTicks.pop();
+                }
+                calcClicks.unshift(App.game.statistics.clickAttacks());
+                if (calcClicks.length > 10) {
+                    calcClicks.pop();
+                }
+                calcEnemies.unshift(App.game.statistics.totalPokemonDefeated());
+                if (calcEnemies.length > 10) {
+                    calcEnemies.pop();
+                }
+            } 
+            // Reset statistics on area / game state change
+            else {
+                resetCalculator();
+            }
+        }, 1000);
+    }
+}
+
+
+/**
+ * Resets stats trackers and calculator info display
+ */
+function resetCalculator() {
+    calcTicks = [0];
+    calcClicks = [App.game.statistics.clickAttacks()];
+    calcEnemies = [App.game.statistics.totalPokemonDefeated()];
+    playerTown = player.town().name;
+    playerRoute = player.route();
+    calculateAreaHealth();
+    document.getElementById('auto-click-info').innerHTML = `<div>Clicker Efficiency:<br><div id="tick-percentage" style="font-weight:bold;">-</div></div>
+        <div>${calculatorDisplayMode == 0 ? 'Clicks/s' : 'DPS'}:<br><div id="clicks-per-second" style="font-weight:bold;">-</div></div>
+        <div>Req. ${calculatorDisplayMode == 0 ? 'Clicks' : 'Click Damage'}:<br><div id="req-clicks" style="font-weight:bold;">-</div></div>
+        <div>Enemies/s:<br><div id="enemies-per-second" style="font-weight:bold; color:black;">-</div></div>`;
+}
+
+
+/**
+ * Check whether player state or location has changed
+ */
+function hasPlayerMoved() {
+    // TODO make this play more nicely with all-gyms mode before that can be enabled
+    var moved = false;
+    if (calcPlayerState != App.game.gameState) {
+        calcPlayerState = App.game.gameState;
+        moved = true;
+    }
+    if (calcPlayerState === GameConstants.GameState.gym) {
+        if (calcPlayerLocation != GymRunner.gymObservable().leaderName) {
+            moved = true;
+        }
+        calcPlayerLocation = GymRunner.gymObservable().leaderName;
+    } else if (calcPlayerState === GameConstants.GameState.dungeon) {
+        if (calcPlayerLocation != DungeonRunner.dungeon.name) {
+            moved = true;
+        }
+        calcPlayerLocation = DungeonRunner.dungeon.name;
+    } else {
+        // Conveniently, player.route() = 0 when not on a route
+        if (calcPlayerLocation != (player.route() || player.town().name)) {
+            moved = true;
+        }
+        calcPlayerLocation = player.route() || player.town().name;
+    }
+    return moved;
+}
+
+/**
+ * Calculate max Pokemon health for the current route/gym/dungeon
+ * -Ignores dungeon boss HP and chest HP increases
+ */
+function calculateAreaHealth() {
+    // Calculate area max hp
+    if (App.game.gameState === GameConstants.GameState.fighting) {
+        calcAreaHealth = PokemonFactory.routeHealth(player.route(), player.region);
+        // Adjust for route health variation
+        // TODO actually calculate the route's maximum health variation
+        calcAreaHealth = Math.round(calcAreaHealth * 1.1);
+    } else if (App.game.gameState === GameConstants.GameState.gym) {
+        // Get highest health gym pokemon
+        calcAreaHealth = GymRunner.gymObservable().getPokemonList().reduce((a, b) => Math.max(a, b.maxHealth), 0);
+    } else if (App.game.gameState === GameConstants.GameState.dungeon) {
+        calcAreaHealth = DungeonRunner.dungeon.baseHealth;
+    } else {
+        calcAreaHealth = 0;
+    }
+}
+
+/* Graphics settings */
+
+/**
+ * Add extra Knockout data bindings to optionally disable (most) gym and dungeon graphics
+ */
+function addGraphicsBindings() {
+    // Add computed observable functions
+    GymRunner.autoGymOn = ko.pureComputed( () => {
+        return autoClickState() && autoGymState();
+    });
+    GymRunner.disableAutoGymGraphics = ko.pureComputed( () => {
+        return gymGraphicsDisabled() && GymRunner.autoGymOn();
+    });
+    DungeonRunner.disableAutoDungeonGraphics = ko.pureComputed( () => {
+        return dungeonGraphicsDisabled() && autoClickState() && autoDungeonState();
+    });
+    /*
+    GymBattle.leaderNameComputable = ko.pureComputed( () => {
+        gymChangedNotifier();
+        return GymBattle.gym.leaderName;
+    });
+    GymBattle.imagePathComputable = ko.pureComputed( () => {
+        gymChangedNotifier();
+        return GymBattle.gym.imagePath;
+    });
+    */
+
+    // Add gymView data bindings
+    var gymContainer = document.querySelector('div[data-bind="if: App.game.gameState === GameConstants.GameState.gym"]');
+    var elemsToBind = ['knockout[data-bind*="pokemonNameTemplate"]', // Pokemon name
+        'span[data-bind*="pokemonsDefeatedComputable"]', // Gym Pokemon counter (pt 1)
+        'span[data-bind*="pokemonsUndefeatedComputable"]', // Gym Pokemon counter (pt 2)
+        'knockout[data-bind*="pokemonSpriteTemplate"]', // Pokemon sprite
+        'div.progress.hitpoints', // Pokemon healthbar
+        'div.progress.timer' // Gym timer
+        ];
+    elemsToBind.forEach((query) => {
+        var elem = gymContainer.querySelector(query);
+        if (elem) {
+            elem.before(new Comment("ko ifnot: GymRunner.disableAutoGymGraphics()"));
+            elem.after(new Comment("/ko"))
+        }
+    });
+    // Always hide stop button during autoGym, even with graphics enabled 
+    var restartButton = gymContainer.querySelector('button[data-bind="visible: GymRunner.autoRestart()"]');
+    restartButton.setAttribute('data-bind', 'visible: GymRunner.autoRestart() && !GymRunner.autoGymOn()');
+    // Make leader name and sprites use observables to support gym-cycling mode
+    /*
+    var leaderNameElem = gymContainer.querySelector('knockout[data-bind*="GymBattle.gym.leaderName"]');
+    leaderNameElem.setAttribute('data-bind', leaderNameElem.getAttribute('data-bind').replace('GymBattle.gym.leaderName', 'GymBattle.leaderNameComputable()'));
+    var leaderSpriteElem = gymContainer.querySelector('img[data-bind*="GymBattle.gym.imagePath"]');
+    leaderSpriteElem.setAttribute('data-bind', leaderSpriteElem.getAttribute('data-bind').replace('GymBattle.gym.imagePath', 'GymBattle.imagePathComputable()'));
+    */
+
+    // Add dungeonView data bindings
+    var dungeonContainer = document.querySelector('div[data-bind="if: App.game.gameState === GameConstants.GameState.dungeon"]');
+    // Title bar contents
+    dungeonContainer.querySelector('h2.pageItemTitle')?.prepend(new Comment("ko ifnot: DungeonRunner.disableAutoDungeonGraphics()"));
+    dungeonContainer.querySelector('h2.pageItemTitle')?.append(new Comment("/ko"));
+    // Main container sprites etc
+    dungeonContainer.querySelector('h2.pageItemTitle')?.after(new Comment("ko ifnot: DungeonRunner.disableAutoDungeonGraphics()"));
+    dungeonContainer.querySelector('h2.pageItemFooter')?.before(new Comment("/ko"));
+}
+
+/* Initializing variables from localStorage */
+
+/**
+ * Loads variable from localStorage
+ * -Returns value from localStorage if it exists and is correct type
+ * -Otherwise returns null
+ */
+function validateStorage(key, type) {
+    try { 
+        var val = localStorage.getItem(key);
+        if (val === null) {
+            throw new Error();
+        }
+        val = JSON.parse(val);
+        if (typeof val !== type) {
+            throw new Error();
+        }
+        return val;
+    } catch (e) {
+        return null;
+    }
+}
+
+// Auto Clicker
+autoClickState(validateStorage('autoClickState', 'boolean') ?? false);
+autoClickMultiplier = validateStorage('autoClickMultiplier', 'number') ?? 1;
+if (!(Number.isInteger(autoClickMultiplier) && autoClickMultiplier >= 1)) {
+    autoClickMultiplier = 1;
+}
+
+// Auto Gym
+autoGymState(validateStorage('autoGymState', 'boolean') ?? false);
+autoGymSelect = validateStorage('autoGymSelect', 'number') ?? 0;
+if (![0, 1, 2, 3, 4, 100].includes(autoGymSelect)) {
+    autoGymSelect = 0;
+}
+
+// Auto Dungeon
+autoDungeonState(validateStorage('autoDungeonState', 'boolean') ?? false);
+autoDungeonMode = validateStorage('autoDungeonMode', 'number') ?? 0;
+if (![0, 1].includes(autoDungeonMode)) {
+    autoDungeonMode = 0;
+}
+
+// Stats calculator
+calculatorDisplayMode = validateStorage('calculatorDisplayMode', 'number') ?? 0;
+if (![0, 1].includes(calculatorDisplayMode)) {
+    calculatorDisplayMode = 0;
+}
+
+// Graphics settings
+gymGraphicsDisabled(validateStorage('gymGraphicsDisabled', 'boolean') ?? false);
+dungeonGraphicsDisabled(validateStorage('dungeonGraphicsDisabled', 'boolean') ?? false);
+
+/* Load script */
+
+// Add data bindings before the game initializes Knockout
+addGraphicsBindings();
+
+function loadScript() {
+    const oldInit = Preload.hideSplashScreen;
+
+    Preload.hideSplashScreen = function () {
+        var result = oldInit.apply(this, arguments);
+        initAutoClicker();
+        return result;
+    }
+}
 
 if (document.getElementById('scriptHandler') != undefined) {
-    var scriptElement = document.createElement('div')
-    scriptElement.id = scriptName
-    document.getElementById('scriptHandler').appendChild(scriptElement)
+    var scriptElement = document.createElement('div');
+    scriptElement.id = scriptName;
+    document.getElementById('scriptHandler').appendChild(scriptElement);
     if (localStorage.getItem(scriptName) != null) {
         if (localStorage.getItem(scriptName) == 'true') {
-            loadScript()
+            loadScript();
         }
     }
     else {
         localStorage.setItem(scriptName, 'true')
-        loadScript()
+        loadScript();
     }
 }
 else {
     loadScript();
-}
-
-function validParse(key) {
-    try {
-        if (key === null) {
-            throw new Error;
-        }
-        JSON.parse(key);
-        return true;
-    } catch (e) {
-        return false;
-    }
-}
-
-function addGlobalStyle(css) {
-    var head, style;
-    head = document.getElementsByTagName('head')[0];
-    if (!head) { return; }
-    style = document.createElement('style');
-    style.type = 'text/css';
-    style.innerHTML = css;
-    head.appendChild(style);
 }

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -214,7 +214,11 @@ function changeSelectedGym(event) {
     if ([0, 1, 2, 3, 4, 100].includes(val)) {
         autoGymSelect = val;
         localStorage.setItem("autoGymSelect", autoGymSelect);
-        // In case currently fighting a gym 
+        // In case currently fighting a gym
+        if (autoClickState() && autoGymState()) {
+            // Since gym-cycling support (below) is disabled
+            GymRunner.autoRestart(false);
+        }
         //setGymIndex(autoGymSelect);
         //gymChanged = true;
     }

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -18,7 +18,7 @@
 // @run-at        document-idle
 // ==/UserScript==
 
-const scriptName = 'enhancedautoclicker';
+var scriptName = 'enhancedautoclicker';
 const ticksPerSecond = 20;
 // Auto Clicker
 var autoClickState = ko.observable(false);
@@ -215,11 +215,13 @@ function changeSelectedGym(event) {
     if ([0, 1, 2, 3, 4, 100].includes(val)) {
         autoGymSelect = val;
         localStorage.setItem("autoGymSelect", autoGymSelect);
-        // In case currently fighting a gym
+        // In case currently fighting a gym 
+        // TODO temporary, replace this with the commented code below once gym-cycling gets enabled
         if (autoClickState() && autoGymState()) {
-        // Only break out of this script's auto restart, not the built-in one
-          GymRunner.autoRestart(false);
+            // Only break out of this script's auto restart, not the built-in one
+            GymRunner.autoRestart(false);
         }
+        // For gym-cycling purposes
         //setGymIndex(autoGymSelect);
         //gymChanged = true;
     }


### PR DESCRIPTION
Rewrote most of the autoclicker for improved performance and stability. Noteworthy changes:

Auto Clicker:
-Reworked variable click delay into a variable click multiplier, enabling higher DPS without the performance hits of going beyond 20 ticks per second
-Improved performance

Auto Gym:
-Reworked to restart gym without loading town in between, dramatically improving performance
-Added setting similar to Additional Visual Settings to disable most battle graphics while Auto Gym is running
-All gyms mode currently disabled due to stability issues with the new Auto Gym implementation and not meshing well with the statistics calculator; I left my mostly-functional code for it in and commented out

Auto Dungeon:
-Full clear mode now waits to open chests until right before the boss, decreasing clear time
-Boss mode now uses Flash, if unlocked, to locate the boss much more efficiently
-Reworked to restart dungeon without loading town in between, improving performance
-Reworked both pathfinding modes to be much more performant
-Added setting similar to Additional Visual Settings to disable most battle graphics while Auto Dungeon is running

Auto Clicker statistics:
-Added ability to switch between clicks and damage display modes
-Now displays how close to max efficiency the clicker is running
-Now averages all stats across the last 10 seconds for improved accuracy
-Now calculates actual max health for the current location

Misc
-Reorganized code and refactored naming for clarity
-Improved validation of variables loaded from localStorage 
-Lots of comments

Implements #98, fixes #91 (and probably others I didn't find)