### PR TITLE
New script: Overnight Berry Growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You may also [join my Discord server](https://discord.gg/nfbT8zJSkd) (can also c
 5. [**Infinite Seasonal Events** ](//github.com/Ephenia/Pokeclicker-Scripts#custom-infinite-seasonal-events-infiniteseasonaleventsuserjs-one-click-install)
 6. [**Oak Items Unlimited** ](//github.com/Ephenia/Pokeclicker-Scripts#custom-oak-iems-unlimited-oakitemsunlimiteduserjs-one-click-install)
 7. [**Omega Protein Gains** ](//github.com/Ephenia/Pokeclicker-Scripts#custom-omega-protein-gains-omegaproteingainsuserjs-one-click-install)
+7. [**Overnight Berry Growth** ](//github.com/Ephenia/Pokeclicker-Scripts#custom-overnight-berry-growth-overnightberrygrowth-one-click-install)
 8. [**Perky Pokerus Pandemic** ](//github.com/Ephenia/Pokeclicker-Scripts#custom-perky-pokerus-pandemic-perkypokeruspandemicuserjs-one-click-install)
 9. [**Simple Weather Changer** ](//github.com/Ephenia/Pokeclicker-Scripts#custom-simple-weather-changer-simpleweatherchangeruserjs-one-click-install)
 
@@ -371,6 +372,15 @@ This script removes the limit for the amount of Proteins that you're able to use
 ![image](https://i.imgur.com/2kXCzUA.png)
 
 I haven't tested the limits of how many Proteins you can give, but it should practically be infinite.
+
+<hr>
+
+## **[Custom] Overnight Berry Growth** ([overnightberrygrowth.user.js](//github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/overnightberrygrowth.user.js)) ([One-Click Install](//github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/overnightberrygrowth.user.js))
+This script allows berries to grow while the game is closed, simulating their growth when the game loads. No mutations occur, aside from Kebia replanting, and Farm Hands are not active. Withered berries can replant as normal, but the script will ignore replanted berries to avoid lag. You can choose between three modes in the settings: 
+
+- Until ripe: Berries will only grow until they are ripe and no time will pass for already-ripe berries. The default mode.
+- Until withered: Berries will continue aging once they are ripe and may wither.
+- Harvest before withering: Berries will continue aging once they are ripe, but the script harvests berries right before they would wither (during offline growth only).
 
 <hr>
 

--- a/custom/overnightberries.user.js
+++ b/custom/overnightberries.user.js
@@ -39,7 +39,7 @@ function initSettings() {
         <select id="select-overnightGrowthMode" class="form-control">
         <option value="0">Until ripe</option>
         <option value="1">Until withered</option>
-        <option value="2">Harvest before withered</option>
+        <option value="2">Harvest before withering</option>
         </select>
         </td>`;
     settingsHeader.after(...settingsElems);

--- a/custom/overnightberries.user.js
+++ b/custom/overnightberries.user.js
@@ -1,0 +1,205 @@
+// ==UserScript==
+// @name          [Pokeclicker] Overnight Berries
+// @namespace     Pokeclicker Scripts
+// @author        Optimatum (Credit: Ephenia)
+// @description   Allows berres to grow while the game is closed.
+// @copyright     https://github.com/Ephenia
+// @license       GPL-3.0 License
+// @version       1.0
+
+// @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
+// @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
+// @downloadURL   https://raw.githubusercontent.com/Ephenia/Pokeclicker-Scripts/master/custom/overnightberries.user.js
+// @updateURL     https://raw.githubusercontent.com/Ephenia/Pokeclicker-Scripts/master/custom/overnightberries.user.js
+
+// @match         https://www.pokeclicker.com/
+// @icon          https://www.google.com/s2/favicons?domain=pokeclicker.com
+// @grant         none
+// @run-at        document-idle
+// ==/UserScript==
+
+
+const scriptName = "overnightberries";
+var overnightGrowthMode;
+const stageMargin = 2; // buffer in seconds around stage changes
+
+
+function initSettings() {
+    // Add settings to settings menu
+    var settingsHeader = document.createElement("tr");
+    settingsHeader.innerHTML = '<th colspan="2">Overnight Berries settings</th>';
+    document.getElementById('settingsModal').querySelector('tr[data-bind*="showMuteButton"]').after(settingsHeader);
+
+    var settingsElems = [];
+    settingsElems.push(document.createElement('tr'));
+    settingsElems.at(-1).innerHTML = `<td class="p-2">
+        Game closed berry growth mode
+        </td>
+        <td class="p-0">
+        <select id="select-overnightGrowthMode" class="form-control">
+        <option value="0">Until ripe</option>
+        <option value="1">Until withered</option>
+        <option value="2">Harvest before withered</option>
+        </select>
+        </td>`;
+    settingsHeader.after(...settingsElems);
+
+    document.getElementById('select-overnightGrowthMode').value = overnightGrowthMode;
+    document.getElementById('select-overnightGrowthMode').addEventListener('change', (event) => { changeGrowthMode(event); } );;
+}
+
+function changeGrowthMode(event) {
+    const val = +event.target.value;
+    overnightGrowthMode = val;
+    localStorage.setItem("overnightGrowthMode", overnightGrowthMode);
+}
+
+class trackPlot {
+    constructor(plot) {
+        this.plot = plot;
+    }
+    calcUpdateTime() {
+        // adapted from Plot.calcFormattedStageTimeLeft
+        const growthTime = this.plot.berryData.growthTime.find(t => this.plot.age < t);
+        const timeLeft = Math.ceil(growthTime - this.plot.age);
+        const growthMultiplier = App.game.farming.getGrowthMultiplier() * this.plot.getGrowthMultiplier();
+        this.timeToNextStage = Math.ceil(timeLeft / growthMultiplier);
+    }
+}
+
+function growOffline(timeToGrow) {
+    var plotList = [];
+    // build berry list
+    for (const plot of App.game.farming.plotList) {
+        if (plot.berry != undefined && plot.berry != BerryType.None) {
+            // account for berries already ripe in until-ripe mode
+            if (!(overnightGrowthMode == 0 && plot.stage() == PlotStage.Berry)) {
+                plotList.push(new trackPlot(plot));
+            }
+        }
+    }
+    // repeatedly add just enough time for one berry to change stage
+    // (adding all at once risks unpredictable growth with auras)
+    while (timeToGrow > 0 && plotList.length > 0) {
+        for (const tracker of plotList) {
+            tracker.calcUpdateTime();
+        }
+        // sort in descending order
+        plotList.sort((a, b) => (b.timeToNextStage - a.timeToNextStage));
+        var growthTimeThisLoop = Math.min(plotList.at(-1).timeToNextStage, timeToGrow);
+        // grow until right before a stage change to avoid auras changing
+        for (const tracker of plotList) {
+            tracker.plot.update(Math.max(growthTimeThisLoop - stageMargin, 0));
+        }
+        // add last second(s) for stage change
+        for (var i = 0; i < plotList.length; i++) {
+            const tracker = plotList[i];
+            if (tracker.timeToNextStage == growthTimeThisLoop) {
+                tracker.calcUpdateTime()
+            }
+            if (tracker.timeToNextStage <= stageMargin) {
+                var toRemove = changeStage(tracker.plot);
+                if (toRemove) {
+                    plotList.splice(i, 1);
+                    i--;
+                }
+            } else {
+                tracker.plot.update(stageMargin);
+            }
+        }
+        timeToGrow -= growthTimeThisLoop;
+    }
+}
+
+function changeStage(plot) {
+    var stage = plot.stage();
+    // until ripe
+    if (overnightGrowthMode == 0) {
+        if (stage === PlotStage.Bloom) {
+            plot.update(stageMargin);
+            return true;
+        }
+    }
+    // until withered
+    else if (overnightGrowthMode == 1) {
+        if (stage === PlotStage.Berry) {
+            plot.update(stageMargin);
+            return true;
+        }
+    }
+    // harvest before wither
+    else if (overnightGrowthMode == 2) {
+        if (stage === PlotStage.Berry) {
+            var i = App.game.farming.plotList.indexOf(plot);
+            App.game.farming.harvest(i);
+            return true;
+        }
+    }
+    // just-in-case check
+    else if (stage === PlotStage.Berry) {
+        plot.update(stageMargin);
+        return true;
+    }
+    plot.update(stageMargin);
+    return false;
+}
+
+function validateStorage(key, type) {
+    try { 
+        var val = localStorage.getItem(key);
+        if (val === null) {
+            throw new Error();
+        }
+        val = JSON.parse(val);
+        if (typeof val !== type) {
+            throw new Error();
+        }
+        return val;
+    } catch (e) {
+        return null;
+    }
+}
+
+
+overnightGrowthMode = validateStorage('overnightGrowthMode', 'number') ?? 0;
+if (![0, 1, 2].includes(overnightGrowthMode)) {
+    overnightGrowthMode = 0;
+}
+
+
+const computeOfflineOld = Game.prototype.computeOfflineEarnings;
+Game.prototype.computeOfflineEarnings = function () {
+    var elapsedTime = Math.floor((Date.now() - player._lastSeen) / 1000);
+    var returnVal = computeOfflineOld.apply(this, arguments);
+    growOffline(elapsedTime);
+    return returnVal;
+}
+
+
+function loadScript() {
+    const oldInit = Preload.hideSplashScreen;
+
+    Preload.hideSplashScreen = function () {
+        var result = oldInit.apply(this, arguments);
+        initSettings();
+        return result;
+    }
+}
+
+if (document.getElementById('scriptHandler') != undefined) {
+    var scriptElement = document.createElement('div');
+    scriptElement.id = scriptName;
+    document.getElementById('scriptHandler').appendChild(scriptElement);
+    if (localStorage.getItem(scriptName) != null) {
+        if (localStorage.getItem(scriptName) == 'true') {
+            loadScript();
+        }
+    }
+    else {
+        localStorage.setItem(scriptName, 'true')
+        loadScript();
+    }
+}
+else {
+    loadScript();
+}

--- a/custom/overnightberries.user.js
+++ b/custom/overnightberries.user.js
@@ -18,7 +18,7 @@
 // @run-at        document-idle
 // ==/UserScript==
 
-const scriptName = "overnightberries";
+var scriptName = "overnightberries";
 const stageMargin = 2; // buffer in seconds around stage changes
 var overnightGrowthMode;
 

--- a/custom/overnightberrygrowth.user.js
+++ b/custom/overnightberrygrowth.user.js
@@ -73,7 +73,7 @@ class trackPlot {
     calcUpdateTime() {
         // adapted from Plot.calcFormattedStageTimeLeft
         const growthTime = this.plot.berryData.growthTime.find(t => this.plot.age < t);
-        const timeLeft = Math.ceil(growthTime - this.plot.age);
+        const timeLeft = growthTime - this.plot.age;
         const growthMultiplier = App.game.farming.getGrowthMultiplier() * this.plot.getGrowthMultiplier();
         this.timeLeft = Math.ceil(timeLeft / growthMultiplier);
         this.isRipe = (this.plot.stage() === PlotStage.Berry);
@@ -126,6 +126,10 @@ function changeStage(plot) {
     if (overnightGrowthMode == 0) {
         if (stage === PlotStage.Bloom) {
             plot.update(stageMargin);
+            return true;
+        }
+        // just-in-case check
+        else if (stage === PlotStage.Berry) {
             return true;
         }
     }

--- a/custom/overnightberrygrowth.user.js
+++ b/custom/overnightberrygrowth.user.js
@@ -9,8 +9,8 @@
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
-// @downloadURL   https://raw.githubusercontent.com/Ephenia/Pokeclicker-Scripts/master/custom/overnightberries.user.js
-// @updateURL     https://raw.githubusercontent.com/Ephenia/Pokeclicker-Scripts/master/custom/overnightberries.user.js
+// @downloadURL   https://raw.githubusercontent.com/Ephenia/Pokeclicker-Scripts/master/custom/overnightberrygrowth.user.js
+// @updateURL     https://raw.githubusercontent.com/Ephenia/Pokeclicker-Scripts/master/custom/overnightberrygrowth.user.js
 
 // @match         https://www.pokeclicker.com/
 // @icon          https://www.google.com/s2/favicons?domain=pokeclicker.com
@@ -18,7 +18,7 @@
 // @run-at        document-idle
 // ==/UserScript==
 
-var scriptName = "overnightberries";
+var scriptName = "overnightberrygrowth";
 const stageMargin = 2; // buffer in seconds around stage changes
 var overnightGrowthMode;
 


### PR DESCRIPTION
Farming lategame berries that take days to grow is extremely annoying if you don't want to leave the game open constantly. This script allows berries to grow while the game is closed.

The script simulates growth for the length of time the game was closed, accounting for auras and mulch. Withered berries replant as usual, but replanted berries do not grow to avoid potential lag after long breaks. Farm helpers are not used and (non-Kasib) mutations do not occur.  There are three modes to choose between, to suit your personal play style:

- Until ripe: Berries grow only until they are ripe. No rush to return to the game, no risk of destroying a carefully-arranged farm setup. The most forgiving option.
- Until withered: Berries continue aging until they wither. A less-forgiving experience more accurate to leaving the base game running.
- Harvest before withering: Berries continue aging once they are ripe, but if enough time has passed for them to wither, the script will harvest them immediately before they would wither. Somewhat more forgiving but denies you the chance to use rich mulch or other boosts.

I haven't rigorously tested this, so please let me know if you run into any issues and I'll try to fix them.