### PR TITLE
PokéClicker v0.10.11 Catch Speed Adjuster + Scripthandler.js / app.asar fixes. Also Infinite Seasonal Events images fix.

### DIFF
--- a/custom/catchspeedadjuster.user.js
+++ b/custom/catchspeedadjuster.user.js
@@ -5,7 +5,7 @@
 // @description   Adjusts catch speed of all Pokeballs. Currently only makes Pokeballs catch as fast as possible.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.2
+// @version       1.3
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -26,10 +26,11 @@ function initBallAdjust() {
     for (var i = 0; i < getBalls.length; i++) {
         defaultTime.push(getBalls[i].catchTime)
     }
-    var ballCont = document.getElementById('pokeballSelectorBody').querySelector('thead');
+    var ballCont = document.getElementById('pokeballFilters');
     var ballAdj = document.createElement("tr");
-    ballAdj.innerHTML = `<td colspan="5"><div style="height: 25px;"><label for="ball-adjust">0 Delay Capture <label><input id="ball-adjust" type="checkbox" style="position: relative;top: 2px;"></div></td>`
+    ballAdj.innerHTML = `<td colspan="3"><div style="height: 25px;"><label for="ball-adjust">0 Delay Capture <label><input id="ball-adjust" type="checkbox" style="position: relative;top: 2px;"></div></td>`
     ballCont.append(ballAdj)
+    document.getElementById('pokeballSelectorBody').style.maxHeight = "285px";
     document.getElementById('ball-adjust').addEventListener('click', event => changeAdjust(event.target));
 
     if (ballAdjuster == "true") {

--- a/custom/infiniteseasonalevents.user.js
+++ b/custom/infiniteseasonalevents.user.js
@@ -5,7 +5,7 @@
 // @description   Adds in toggable options to have seasonal events infinitely run. Events can also run simultaneously with one another. Includes custom events as well.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.1
+// @version       1.2
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -103,25 +103,25 @@ function initEvents() {
             case "Flying Pikachu":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
-                <img src="assets/images/pokemon/25.08.png">
-                <img src="assets/images/pokemon/21.1.png">
+                <img src="assets/images/pokemon/25.1.png">
+                <img src="assets/images/pokemon/21.01.png">
                 </div><hr>`
                 break
             case "Mewtwo strikes back!":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
-                <img src="assets/images/pokemon/150.1.png">
-                <img src="assets/images/pokemon/1.1.png">
-                <img src="assets/images/pokemon/4.1.png">
-                <img src="assets/images/pokemon/7.1.png">
+                <img src="assets/images/pokemon/150.03.png">
+                <img src="assets/images/pokemon/1.01.png">
+                <img src="assets/images/pokemon/4.01.png">
+                <img src="assets/images/pokemon/7.01.png">
                 </div><hr>`
                 break
             case "Halloween!":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
-                <img src="assets/images/pokemon/1.2.png">
-                <img src="assets/images/pokemon/175.1.png">
-                <img src="assets/images/pokemon/25.1.png"><br>
+                <img src="assets/images/pokemon/1.02.png">
+                <img src="assets/images/pokemon/25.12.png">
+                <img src="assets/images/pokemon/175.01.png"><br>
                 <img src="assets/images/pokemon/92.png">
                 <img src="assets/images/pokemon/200.png">
                 <img src="assets/images/pokemon/353.png">
@@ -131,40 +131,60 @@ function initEvents() {
             case "Let's GO!":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
-                <img src="assets/images/pokemon/133.1.png">
-                <img src="assets/images/pokemon/25.11.png">
+                <img src="assets/images/pokemon/25.13.png">
+                <img src="assets/images/pokemon/133.02.png">
                 </div><hr>`
                 break
             case "Merry Christmas!":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
-                <img src="assets/images/pokemon/143.1.png">
-                <img src="assets/images/pokemon/251.1.png">
-                <img src="assets/images/pokemon/446.1.png">
+                <img src="assets/images/pokemon/143.02.png">
+                <img src="assets/images/pokemon/251.01.png">
+                <img src="assets/images/pokemon/446.01.png">
                 </div><hr>`
                 break
             case "Hoopa Day":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
+                <i>(Note that this event only adds a special joke questline and doesn't add Hoopa as an additional roamer. Hoopa is available without this event.)</i><br>
                 <img src="assets/images/pokemon/720.png">
                 </div><hr>`
                 break
             case "Lunar New Year":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
-                <img src="assets/images/pokemon/666.19.png">
+                <img src="assets/images/pokemon/666.png">
+                <img src="assets/images/pokemon/666.19.png"><br>
+                <img src="assets/images/pokemon/666.01.png">
+                <img src="assets/images/pokemon/666.02.png">
+                <img src="assets/images/pokemon/666.03.png">
+                <img src="assets/images/pokemon/666.04.png">
+                <img src="assets/images/pokemon/666.05.png">
+                <img src="assets/images/pokemon/666.06.png">
+                <img src="assets/images/pokemon/666.07.png">
+                <img src="assets/images/pokemon/666.08.png">
+                <img src="assets/images/pokemon/666.09.png">
+                <img src="assets/images/pokemon/666.1.png">
+                <img src="assets/images/pokemon/666.11.png">
+                <img src="assets/images/pokemon/666.12.png">
+                <img src="assets/images/pokemon/666.13.png">
+                <img src="assets/images/pokemon/666.14.png">
+                <img src="assets/images/pokemon/666.15.png">
+                <img src="assets/images/pokemon/666.16.png">
+                <img src="assets/images/pokemon/666.17.png">
+                <img src="assets/images/pokemon/666.18.png">
                 </div><hr>`
                 break
             case "Easter":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
-                <img src="assets/images/pokemon/175.2.png">
+                <img src="assets/images/pokemon/175.02.png">
                 </div><hr>`
                 break
             case "Golden Week":
                 modalBody.innerHTML +=
                     `<div id="event-`+i+`" class="event-select" data-value="`+i+`"><b>`+getEvents[i].title+`</b><br>`+getEvents[i].description+`<br>
-                <img src="assets/images/pokemon/1.3.png">
+                <img src="assets/images/pokemon/1.03.png">
                 </div><hr>`
                 break
             case "Ephenia's Gift":

--- a/desktop/app_src/src/scripthandler.js
+++ b/desktop/app_src/src/scripthandler.js
@@ -10,7 +10,7 @@
                 document.getElementById('settingsModal').querySelector('div').style.maxWidth = '850px'
 
                 //Select the top header row of tabs in Settings
-                const settingTabs = document.querySelectorAll('.nav.nav-tabs.nav-fill')[1];
+                const settingTabs = document.querySelectorAll('.nav.nav-tabs.nav-fill')[2];
 
                 //Create and append the new tab for scripts to Settings
                 let scriptFrag = new DocumentFragment();
@@ -21,7 +21,7 @@
                 settingTabs.appendChild(scriptFrag);
 
                 //Select the parent element that contains the content of the tabs
-                const tabContent = document.querySelectorAll('.tab-content')[3];
+                const tabContent = document.querySelectorAll('.tab-content')[4];
 
                 //Create and append the content for the script tab to Settings
                 scriptFrag = new DocumentFragment();


### PR DESCRIPTION
The new 0.10.11 update made some changes to the game. This broke some scripts, and this PR aims to fix that.
After a few hours of test with the fixes, everything seems fine.

## Catch Speed Adjuster fix
0.10.11 modified the Pokéball selector by adding filters.
I changed the colspan from the script, and moved the Delay Capture checkbox to the bottom.
<table>
	<tr align="center">
		<td><b>Before fix</b></td>
		<td><b>After fix</b></td>
	</tr>
	<tr>
		<td><img src="https://user-images.githubusercontent.com/89878127/236692353-a236f3b8-dbd6-470d-928d-4f274fb12afb.png"></td>
		<td> <img src="https://user-images.githubusercontent.com/89878127/236692351-6b823e17-dec9-46d3-974c-efd90b071940.png"></td>
	</tr>
</table>


## scripthandler.js + app.asar fix
0.10.11 update added new tabs in the Log Book modal. As a consequence, the Scripts tab was moved into it.
I updated the `scripthandler.js` file to move back the Scripts tab in the Settings modal.
I repacked the `app.asar` file using the `asar pack app_src app.asar` command on Windows, so I guess it should be good.
<table>
	<tr align="center">
		<td><b>Log Book modal before fix</b></td>
		<td><b>Log Book modal after fix</b></td>
	</tr>
	<tr>
		<td><img src="https://user-images.githubusercontent.com/89878127/236692350-6772f307-f17d-4c02-9718-d4f69936fc8c.png" width=350px></td>
		<td> <img src="https://user-images.githubusercontent.com/89878127/236692349-beeb1641-a000-443f-98c7-d5a55535ce09.png" width=350px></td>
	</tr>
	<tr align="center">
		<td><b>Settings modal before fix</b></td>
		<td><b>Settings modal after fix</b></td>
	</tr>
	<tr>
		<td><img src="https://user-images.githubusercontent.com/89878127/236692355-81462133-c774-4040-a931-a3a1da03ee9e.png" width=350px></td>
		<td> <img src="https://user-images.githubusercontent.com/89878127/236692354-16778c79-365a-4fcf-8cc9-5d0ab2d0c76c.png" width=350px></td>
	</tr>
</table>


## Infinite Seasonal Events fix
Not related to 0.10.11, but I noticed that a lot of images are wrong / broken in the Seasonal Events script. I fixed them and updated some events.
I added all the Vivillon forms for Lunar New Year event, since it makes them all catchable again
I also added a small note for the Hoopa event, since it only gives a new questline and no special Pokémon.
<table>
	<tr align="center">
		<td><b>Before fix</b></td>
		<td><b>After fix</b></td>
	</tr>
	<tr>
		<td><img src="https://user-images.githubusercontent.com/89878127/236692347-ddf43bd3-2cb1-4404-81d5-144ccb46f0c0.png" width=350px></td>
		<td><img src="https://user-images.githubusercontent.com/89878127/236692321-b6a8d686-8432-4595-830f-d9f1e093bd43.png" width=350px></td>
	</tr>
	<tr align="center">
		<td colspan=2><b>Hoopa Event note</b></td>
	</tr>
	<tr align="center">
		<td colspan=2><img src="https://user-images.githubusercontent.com/89878127/236692348-bdfe9798-7b1d-4eb3-8bbd-3d88d673435b.png" width=600px></td>
	</tr>
</table>