### PR TITLE
Update omegaproteingains for new vitamin mechanics

### DIFF
--- a/custom/omegaproteingains.user.js
+++ b/custom/omegaproteingains.user.js
@@ -2,10 +2,10 @@
 // @name          [Pokeclicker] Omega Protein Gains
 // @namespace     Pokeclicker Scripts
 // @author        Ephenia
-// @description   Removes the cap on the amount of Proteins that you can use on Pokémon which effectively makes them infinite use.
+// @description   Removes the cap on the amount of Protein and Calcium that you can use on individual Pokémon, and raises the cap for Carbos.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.0
+// @version       1.1
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -18,51 +18,55 @@
 // @run-at        document-idle
 // ==/UserScript==
 
-var proteinTable;
-var awaitProteinTable;
-var awaitOmegaProtein;
-var newSave;
-var trainerCards;
+// 70 Carbos will make every (non-Magikarp) pokemon hatch in exactly 300 steps
+const maxCarbos = 70;
 
 function initOmegaProtein() {
-    document.getElementById('itemBag').querySelectorAll('div')[2].addEventListener('click', initProtein, true);
-    
-    function initProtein() {
-        //This setInterval is one of the few required ones because this table does not exist until loaded once
-        awaitProteinTable = setInterval(function () {
-            proteinTable = document.getElementById('pokemonSelectorModal').querySelectorAll('tbody')
-            if (proteinTable.length != 0) {
-                clearInterval(awaitProteinTable);
-                proteinTable[0].addEventListener('click', bypassProtein, true);
-                function bypassProtein(event) {
-                    var child = event.target.closest('tr').rowIndex - 1;
-                    var protein = player.itemList.Protein();
-                    var setProtein = VitaminController.getMultiplier()
-                    var usedProtein = protein - setProtein;
-                    var pokeProtein = PartyController.getProteinSortedList()[child].proteinsUsed()
-                    if (setProtein == Infinity && protein > 0) {
-                        PartyController.getProteinSortedList()[child].proteinsUsed(pokeProtein + protein)
-                        player.itemList.Protein(0)
-                    } else if (usedProtein >= 0) {
-                        PartyController.getProteinSortedList()[child].proteinsUsed(pokeProtein + setProtein)
-                        player.itemList.Protein(usedProtein)
-                    } else {
-                        Notifier.notify({
-                            message: `You don't have any Proteins left...`,
-                            type: NotificationConstants.NotificationOption.danger,
-                        });
-                    }
-                    event.stopImmediatePropagation();
-                }
+    // Override useVitamin() to allow adding as many vitamins as desired (except Carbos)
+    PartyPokemon.prototype.useVitamin = function (vitamin, amount) {
+        if (App.game.challenges.list.disableVitamins.active()) {
+            Notifier.notify({
+                title: 'Challenge Mode',
+                message: 'Vitamins are disabled',
+                type: NotificationConstants.NotificationOption.danger,
+            });
+            return;
+        }
+
+        if (this.breeding) {
+            Notifier.notify({
+                message: 'Vitamins cannot be modified for Pokémon in the hatchery or queue.',
+                type: NotificationConstants.NotificationOption.warning,
+            });
+            return;
+        }
+
+        // Limit Carbos to avoid potential bugs from instantly-hatching eggs
+        if (vitamin === GameConstants.VitaminType.Carbos) {
+            if (this.vitaminsUsed[GameConstants.VitaminType.Carbos]() >= maxCarbos) {
+                Notifier.notify({
+                    message: 'This Pokémon cannot hatch any faster!',
+                    type: NotificationConstants.NotificationOption.warning,
+                });
+                return;
             }
-        }, 50);
+            amount = Math.min(amount, Math.max(0, maxCarbos - this.vitaminsUsed[GameConstants.VitaminType.Carbos]()));
+        }
+
+        // The lower number of amount they want to use, total in inventory
+        amount = Math.min(amount, player.itemList[GameConstants.VitaminType[vitamin]]());
+
+        // Apply the vitamin
+        if (ItemHandler.useItem(GameConstants.VitaminType[vitamin], amount)) {
+            GameHelper.incrementObservable(this.vitaminsUsed[vitamin], amount);
+        }
     }
 }
 
-function loadScript(){
+function loadScript() {
     var oldInit = Preload.hideSplashScreen
 
-    Preload.hideSplashScreen = function(){
+    Preload.hideSplashScreen = function () {
         var result = oldInit.apply(this, arguments)
         initOmegaProtein()
         return result
@@ -71,20 +75,20 @@ function loadScript(){
 
 var scriptName = 'omegaproteingains'
 
-if (document.getElementById('scriptHandler') != undefined){
+if (document.getElementById('scriptHandler') != undefined) {
     var scriptElement = document.createElement('div')
     scriptElement.id = scriptName
     document.getElementById('scriptHandler').appendChild(scriptElement)
-    if (localStorage.getItem(scriptName) != null){
-        if (localStorage.getItem(scriptName) == 'true'){
+    if (localStorage.getItem(scriptName) != null) {
+        if (localStorage.getItem(scriptName) == 'true') {
             loadScript()
         }
     }
-    else{
+    else {
         localStorage.setItem(scriptName, 'true')
         loadScript()
     }
 }
-else{
+else {
     loadScript();
 }


### PR DESCRIPTION
Updates Omega Protein Games to support the new vitamins. Instead of updating the existing approach of intercepting clicks, I modified it to overwrite `PartyPokemon.useVitamin()` instead. This should make the script much more resilient to future game updates (new vitamins, UI changes, etc).

The script now supports both individual and combined vitamin menus and both adding and removing vitamins. While there's no cap on using Protein or Calcium, I added a limit to the number of Carbos that players can use on each Pokemon to avoid potential glitches from extremely low step counts rounding to 0. The current limit is 70 Carbos, which under the current formula brings any Pokemon above 300 egg steps to exactly 300 steps.

A better approach to the Carbos issue would be to wrap `PartyPokemon.getEggSteps()` to return 1 at minimum, but modifying the prototype doesn't seem to play nicely with `ko.pureComputed`-wrapped functions. If anyone knows a way to make that work it would be more stable long-term.