### PR TITLE
[Auto Farmer] Better Auto Replant for mutations

### DIFF
--- a/simpleautofarmer.user.js
+++ b/simpleautofarmer.user.js
@@ -182,6 +182,11 @@ function initAutoFarm() {
             let plot = App.game.farming.plotList[i];
             let berry = plot.berry;
             if (berry >= 0) {
+                // Auto-harvest tiles with surprise mulch
+                if (plot.mulch == MulchType.Surprise_Mulch) {
+                    App.game.farming.harvest(i, false);
+                    continue;
+                }
                 var timeLeft = berryData[berry].growthTime[4] - plot.age;
                 timeLeft /= (App.game.farming.getGrowthMultiplier() * plot.getGrowthMultiplier());
                 if (timeLeft < 10) {


### PR DESCRIPTION
I found myself annoyed at having to constantly check the farm to harvest mutated berries and free up space for new mutations, so I adjusted the Auto Replant behavior to account for this.

Now, when Auto Replant is active, berries on tiles with Surprise Mulch will be auto-harvested immediately after growth, and not replanted. Everything else remains unchanged (so berries on tiles with no or any other type of mulch will be harvested at the end of their cycle and replanted as usual).