### PR TITLE
New Auto Dungeon mode + misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It's very important for the future of the project in general and how things will
 [Using the Script Fixer Upper](https://github.com/Ephenia/Pokeclicker-Scripts/issues/214)<br/>
 [Issue Guidelines](https://github.com/Ephenia/Pokeclicker-Scripts/issues/119)
 
-**Only** use scripts if you have read and understood their descriptions!
+**Only** use scripts if you have read and understood their descriptions! Report issues while using scripts here or on the Discord, **not** to the developers of Pokéclicker.
 
 <hr>
 
@@ -61,7 +61,6 @@ You may also [join my Discord server](https://discord.gg/nfbT8zJSkd) (can also c
 7. [**Overnight Berry Growth** ](#overnight-berry-growth)
 8. [**Perky Pokerus Pandemic** ](#perky-pokerus-pandemic)
 9. [**Simple Weather Changer** ](#simple-weather-changer)
-10. [**Auto Safari Zone** ](//github.com/Ephenia/Pokeclicker-Scripts#custom-auto-safari-zone-auto-safarizoneuserjs-one-click-install)
 
 ```diff
 - Note: Please backup your saves before using any and all scripts that would be here!!!
@@ -446,24 +445,6 @@ This script lets you freely edit the weather of the region you are currently in 
 ![image](https://i.imgur.com/2cBIfyH.png)
 
 In addition it will also prevent the weather from changing and will remember you choice when reloading the game
-
-<br>
-
-<hr>
-
-## **[Custom] Auto Safari** ([autosafarizone.user.js](//github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/autosafarizone.user.js)) ([One-Click Install](//github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/autosafarizone.user.js))
-This script automatically explores the Safari Zone and Friend Safari, catching Pokémon and collecting items. You can activate the script while in the menu for either.
-
-The script also has the following options:
-<strong>• Auto Pick Items</strong> - Pick up items when only one ball is left (enabled by default)
-<strong>• Auto Throw Bait</strong> - Throws berries when seeking uncaught or contagious Pokémon, or regular bait if you need a bait achievement. 
-<strong>• Auto Seek New</strong> - Prioritizes catching uncaught Pokémon.
-<strong>• Auto Seek PKRS</strong> - Prioritizes catching contagious Pokémon (below 50 EVs).
-<strong>• Auto Fast Anim</strong> - Increases the speed of many animations. Stacks with the Safari Level speed bonuses.
-
-The auto bait setting will never use your last berry. The script will always use optimal berries to catch shiny Pokémon, whether or not auto bait is enabled.
-
-<br>
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -186,9 +186,10 @@ I think the rest of the buttons there are self-explanatory, and you guys can hav
 <hr>
 
 <h2 id="enhanced-auto-clicker">Enhanced Auto Clicker (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/enhancedautoclicker.user.js">enhancedautoclicker.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/enhancedautoclicker.user.js">One-Click Install</a>)</h2>
-This script is based on one originally created by <b>Ivan Lay</b>, which [can be found here](//github.com/ivanlay/pokeclicker-automator). 
 
-<img width="608" src="https://user-images.githubusercontent.com/12092270/229034199-21bb914c-d6c3-4d97-bc4a-4521052a2740.png">
+This script is based on one originally created by <b>Ivan Lay</b>, which [can be found here](https://github.com/ivanlay/pokeclicker-automator). 
+
+<img width="608" src="https://user-images.githubusercontent.com/12092270/283228302-872fd66d-e8e8-488c-afdd-e9b8ef550d77.png">
 
 The main Auto Clicker button can be found under your currencies. Clicking it toggles the Auto Clicker on/off without the need of a refresh. This setting will also save and persist through page refresh/close.
 
@@ -216,11 +217,14 @@ The Auto Gym feature is found below the Auto Click button. Some notes about how 
 The Auto Dungeon feature is found below the Auto Click button. Some notes about how this works:
 
 • Auto Dungeon will only work while the Auto Clicker is active.<br>
-• Auto Dungeon when activated will automatically explore the current dungeon, or begin exploring a dungeon whose entrance you are at. 
-• There are two dropdowns to the right of the Auto Dungeon button. The first chooses between two modes:<br><br>
-<strong>"F" for Farm mode</strong> - this runs through the dungeon in its entirety and fights all the enemies, saving the boss for last. It now waits to open chests until right before the boss fight for faster clearing.<br/>
-<strong>"B" for Boss mode</strong> - this tries to clear the dungeon as fast as possible to fight the boss. If you have unlocked Flash for a dungeon, this mode will now use it to find the boss while visiting as few columns as possible. It does not include pathfinding that uses information, like the location of the boss, not visible to the player.
-• The second dropdown determines which chests, if any, Auto Dungeon will open. If you choose a tier of chest, Auto Dungeon will open chests of that tier or greater right before fighting the boss. In Farm mode it will open every chest of those tiers; in Boss mode it will open chests that were already visited or are visible with Flash. When "None" is selected, Auto Dungeon will predictably not open chests.
+• Auto Dungeon when activated will automatically explore the current dungeon, or begin exploring a dungeon whose entrance you are at.<br>
+• If Flash is unlocked for a dungeon, Auto Dungeon will use it to explore more efficiently.
+• The two buttons to the right of the Auto Dungeon button control its modes.<br>
+&emsp;• When fights mode is on, Auto Dungeon will find and fight every enemy on the floor.
+&emsp;• When chests mode is on, Auto Dungeon will find every chest on the floor and open them before fighting the boss.
+&emsp;• When neither mode is on (both buttons are greyed out), Auto Dungeon will just find and fight the boss as quickly as possible.
+• The dropdown menu determines which chests Auto Dungeon will open. It will only open chests of the selected rarity or higher.
+&emsp;• If the settings menu option "Always open visible chests..." is enabled, Auto Dungeon will open chests of sufficient rarity even when chests mode is off. It will open any visible chests right before fighting the boss but not explore the floor to reveal potential other chests.
 
 ### **Graphics settings**
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ You may also [join my Discord server](https://discord.gg/nfbT8zJSkd) (can also c
 
 <hr>
 
-<h2 id="additional-visual-settings">Additional Visual Settings (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/additionalvisualsettings.user.js">additionalvisualsettings.user.js</a>) (<a href="//github.com/Ephenia/Pokeclicker-Scripts/raw/master/additionalvisualsettings.user.js">One-Click Install</a>)</h2>
+<a name="additional-visual-settings"></a>
+## Additional Visual Settings (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/additionalvisualsettings.user.js">additionalvisualsettings.user.js</a>) (<a href="//github.com/Ephenia/Pokeclicker-Scripts/raw/master/additionalvisualsettings.user.js">One-Click Install</a>)
 This script adds new options to customize the game's graphics alongside a handful of other quality of life features.
 
 ### **Visual Settings**
@@ -94,7 +95,8 @@ The script adds various buttons for quicker navigation and quality of life.
 
 <hr>
 
-<h2 id="auto-battle-frontier">Auto Battle Frontier (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/autobattlefrontier.user.js">autobattlefrontier.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/autobattlefrontier.user.js">One-Click Install</a>)</h2>
+<a name="auto-battle-frontier"></a>
+## Auto Battle Frontier (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/autobattlefrontier.user.js">autobattlefrontier.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/autobattlefrontier.user.js">One-Click Install</a>)
 This script adds in a stage resetter to the Battle Frontier.<br>
 
 ![](https://github.com/Ephenia/Pokeclicker-Scripts/assets/12092270/3e2200c4-294d-4a9f-9351-b03ff0d2bd96)
@@ -105,7 +107,8 @@ The Max Attacks mode restarts the Battle Frontier when you reach a stage with ba
 
 <hr>
 
-<h2 id="auto-battle-items">Auto Battle Items (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/autobattleitems.user.js">autobattleitems.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/autobattleitems.user.js">One-Click Install</a>)</h2>
+<a name="auto-battle-items"></a>
+## Auto Battle Items (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/autobattleitems.user.js">autobattleitems.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/autobattleitems.user.js">One-Click Install</a>)
 This script adds in automation for Battle Items:<br>
 
 ![image](https://user-images.githubusercontent.com/26987203/178172097-3f733731-a15d-4ed9-b82a-f8476a39a4ff.png)
@@ -120,7 +123,8 @@ Battle Items will automatically be used when you have at least 1 available, as y
 
 <hr>
 
-<h2 id="catch-filter-fantasia">Catch Filter Fantasia (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/catchfilterfantasia.user.js">catchfilterfantasia.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/catchfilterfantasia.user.js">One-Click Install</a>)</h2>
+<a name="catch-filter-fantasia"></a>
+## Catch Filter Fantasia (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/catchfilterfantasia.user.js">catchfilterfantasia.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/catchfilterfantasia.user.js">One-Click Install</a>)
 So, this script would be adding a Filter button to the Pokeballs section:
 
 ![image](https://user-images.githubusercontent.com/26987203/170853489-de1f9304-9a91-45d1-aa0e-904f5c1709ed.png)
@@ -185,7 +189,8 @@ I think the rest of the buttons there are self-explanatory, and you guys can hav
 
 <hr>
 
-<h2 id="enhanced-auto-clicker">Enhanced Auto Clicker (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/enhancedautoclicker.user.js">enhancedautoclicker.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/enhancedautoclicker.user.js">One-Click Install</a>)</h2>
+<a name="enhanced-auto-clicker"></a>
+## Enhanced Auto Clicker (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/enhancedautoclicker.user.js">enhancedautoclicker.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/enhancedautoclicker.user.js">One-Click Install</a>)
 
 This script is based on one originally created by <b>Ivan Lay</b>, which [can be found here](https://github.com/ivanlay/pokeclicker-automator). 
 
@@ -237,7 +242,8 @@ The Auto Clicker now includes graphics settings for Auto Gym and Auto Dungeon to
 
 <hr>
 
-<h2 id="enhanced-auto-hatchery">Enhanced Auto Hatchery (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/enhancedautohatchery.user.js">enhancedautohatchery.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/enhancedautohatchery.user.js">One-Click Install</a>)</h2>
+<a name="enhanced-auto-hatchery"></a>
+## Enhanced Auto Hatchery (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/enhancedautohatchery.user.js">enhancedautohatchery.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/enhancedautohatchery.user.js">One-Click Install</a>)
 This script is based on one created by <b>Ivan Lay & Drak</b> which [can be found over here](//greasyfork.org/en/scripts/432768-auto-hatchery-edit-pokeclicker-com).
 
 The Auto Hatchery automatically hatches eggs and places new eggs/fossils in the hatchery. 
@@ -258,7 +264,8 @@ If none of the above modes are enabled or have targets, the Auto Hatchery will s
 
 <hr>
 
-<h2 id="enhanced-auto-mine">Enhanced Auto Mine (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/enhancedautomine.user.js">enhancedautomine.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/enhancedautomine.user.js">One-Click Install</a>)</h2>
+<a name="enhanced-auto-mine"></a>
+## Enhanced Auto Mine (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/enhancedautomine.user.js">enhancedautomine.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/enhancedautomine.user.js">One-Click Install</a>)
 This script was originally created by <b>Ivan Lay</b> and [can be found over here](//github.com/ivanlay/pokeclicker-automator).
 
 This I had worked quite a bit on, and I'm quite happy with what it's capable of doing. This is far bigger and does a lot more than Ivan Lay's script. However, since I was using it and was inspired, I decided to make an auto miner that's as efficient as possible instead.
@@ -288,7 +295,8 @@ As of 1.1 this also includes 2 more additional features into the Treasures tab o
 
 <hr>
   
-<h2 id="simple-auto-farmer">Simple Auto Farmer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/main/simpleautofarmer.user.js">simpleautofarmer.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/simpleautofarmer.user.js">One-Click Install</a>)</h2>
+<a name="simple-auto-farmer"></a>
+## Simple Auto Farmer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/main/simpleautofarmer.user.js">simpleautofarmer.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/simpleautofarmer.user.js">One-Click Install</a>)
 This script is a simple Auto Farmer which adds 4 new buttons below the Plant and Harvest all buttons as shown:<br>
 
 ![](https://i.imgur.com/ei7lR95.png)
@@ -307,7 +315,8 @@ The Auto Farmer runs even while the farm window is closed. It also now saves you
 
 <hr>
 
-<h2 id="script-fixer-upper">Script Fixer Upper (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/scriptfixerupper.user.js">scriptfixerupper.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/scriptfixerupper.user.js">One-Click Install</a>)</h2>
+<a name="script-fixer-upper"></a>
+## Script Fixer Upper (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/scriptfixerupper.user.js">scriptfixerupper.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/scriptfixerupper.user.js">One-Click Install</a>)
 
 This script resets the settings of all your other installed scripts. It is intended **only** for troubleshooting and fixing buggy behavior, as described [here](//github.com/Ephenia/Pokeclicker-Scripts/issues/214).
 
@@ -317,7 +326,8 @@ This script should be your first step if you are experiencing bugs, especially a
 
 <hr>
 
-<h2 id="script-manager">Script manager (Exclusive to the desktop client) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/desktop/">app.asar</a>)</h2>
+<a name="script-manager"></a>
+## Script manager (Exclusive to the desktop client) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/desktop/">app.asar</a>)
 
 This script provides desktop client support for userscripts, allowing you to run or disable userscripts like a userscript manager browser extension does. All the scripts in this repository are supported and are by default automatically downloaded and updated. It can also run other userscripts that you install. Options are located in the <strong>Scripts</strong> tab in the game's settings menu. 
 
@@ -327,7 +337,8 @@ This script is only compatible with the desktop client. For detailed instruction
 
 <hr>
 
-<h2 id="auto-quest-completer">[Custom] Auto Quest Completer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/autoquestcompleter.user.js">autoquestcompleter.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/autoquestcompleter.user.js">One-Click Install</a>)</h2>
+<a name="auto-quest-completer"></a>
+## [Custom] Auto Quest Completer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/autoquestcompleter.user.js">autoquestcompleter.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/autoquestcompleter.user.js">One-Click Install</a>)
 This script automatically completes and starts quests and can be toggled with this button:<br>
 
 ![image](https://i.imgur.com/3AYaNes.png)
@@ -340,7 +351,8 @@ The script now has settings in the Settings menu that let you customize its beha
 
 <hr>
 
-<h2 id="auto-safari-zone">[Custom] Auto Safari Zone (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/autosafarizone.user.js">autosafarizone.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/autosafarizone.user.js">One-Click Install</a>)</h2>
+<a name="auto-safari-zone"></a>
+## [Custom] Auto Safari Zone (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/autosafarizone.user.js">autosafarizone.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/autosafarizone.user.js">One-Click Install</a>)
 
 This script automatically explores the Safari Zone and Friend Safari, catching Pokémon and collecting items for you. You can activate the script while in the window for either Safari.
 
@@ -355,7 +367,8 @@ The auto bait setting will never use your last berry. The script will always use
 
 <hr>
 
-<h2 id="catch-speed-adjuster">[Custom] Catch Speed Adjuster (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/catchspeedadjuster.user.js">catchspeedadjuster.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/catchspeedadjuster.user.js">One-Click Install</a>)</h2>
+<a name="catch-speed-adjuster"></a>
+## [Custom] Catch Speed Adjuster (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/catchspeedadjuster.user.js">catchspeedadjuster.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/catchspeedadjuster.user.js">One-Click Install</a>)
 This script adds in a new option found below your Pokéballs:<br>
 
 ![image](https://i.imgur.com/C6aVzND.png)
@@ -364,7 +377,8 @@ This currently will make all of your Pokéballs catch Pokémon at 0 delay (basic
 
 <hr>
 
-<h2 id="challenge-mode-changer">[Custom] Challenge Mode Changer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/challengemodechanger.user.js">challengemodechanger.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/challengemodechanger.user.js">One-Click Install</a>)</h2>
+<a name="challenge-mode-changer"></a>
+## [Custom] Challenge Mode Changer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/challengemodechanger.user.js">challengemodechanger.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/challengemodechanger.user.js">One-Click Install</a>)
 This script changes how Challenges work:<br>
 
 ![image](https://i.imgur.com/zsPsiSg.png)
@@ -377,7 +391,8 @@ Also, yes, changing these will give you the respective Challenge ribbons on your
 
 <hr>
   
-<h2 id="discord-code-generator">[Custom] Discord Code Generator (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/discordcodegenerator.user.js">discordcodegenerator.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/discordcodegenerator.user.js">One-Click Install</a>)</h2>
+<a name="discord-code-generator"></a>
+## [Custom] Discord Code Generator (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/discordcodegenerator.user.js">discordcodegenerator.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/discordcodegenerator.user.js">One-Click Install</a>)
 This script will let you generate infinite amounts of Discord codes for all of the exclusive Pokémon locked behind Pokéclicker's Discord bot:<br>
 
 ![image](https://i.imgur.com/5Agit4Q.png)
@@ -390,7 +405,8 @@ This script also works while offline.
 
 <hr>
   
-<h2 id="infinite-seasonal-events">[Custom] Infinite Seasonal Events (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/infiniteseasonalevents.user.js">infiniteseasonalevents.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/infiniteseasonalevents.user.js">One-Click Install</a>)</h2>
+<a name="infinite-seasonal-events"></a>
+## [Custom] Infinite Seasonal Events (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/infiniteseasonalevents.user.js">infiniteseasonalevents.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/infiniteseasonalevents.user.js">One-Click Install</a>)
 This script adds in a new settings option to the top of the Start Menu:<br>
 
 ![image](https://user-images.githubusercontent.com/26987203/139570136-78e45d86-97ce-4fec-aa31-3459fbf19e04.png)
@@ -407,7 +423,8 @@ There may be some other cool or neat custom events added in with this as well.
 
 <hr>
 
-<h2 id="oak-items-unlimited">[Custom] Oak Items Unlimited (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/oakitemsunlimited.user.js">oakitemsunlimited.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/oakitemsunlimited.user.js">One-Click Install</a>)</h2>
+<a name="oak-items-unlimited"></a>
+## [Custom] Oak Items Unlimited (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/oakitemsunlimited.user.js">oakitemsunlimited.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/oakitemsunlimited.user.js">One-Click Install</a>)
 This script removes the limit for the amount of Oak Items that you're able to equip:<br>
 
 ![image](https://i.imgur.com/0Peh94W.png)
@@ -418,7 +435,8 @@ This also removes any requirements needed to unlock any Oak Item slots, meaning 
 
 <hr>
 
-<h2 id="omega-protein-gains">[Custom] Omega Protein Gains (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/omegaproteingains.user.js">omegaproteingains.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/omegaproteingains.user.js">One-Click Install</a>)</h2>
+<a name="omega-protein-gains"></a>
+## [Custom] Omega Protein Gains (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/omegaproteingains.user.js">omegaproteingains.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/omegaproteingains.user.js">One-Click Install</a>)
 This script removes the limit for the amount of Proteins that you're able to use on Pokémon:<br>
 
 ![image](https://i.imgur.com/2kXCzUA.png)
@@ -427,7 +445,8 @@ I haven't tested the limits of how many Proteins you can give, but it should pra
 
 <hr>
 
-<h2 id="overnight-berry-growth">[Custom] Overnight Berry Growth (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/overnightberrygrowth.user.js">overnightberrygrowth.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/overnightberrygrowth.user.js">One-Click Install</a>)</h2>
+<a name="overnight-berry-growth"></a>
+## [Custom] Overnight Berry Growth (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/overnightberrygrowth.user.js">overnightberrygrowth.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/overnightberrygrowth.user.js">One-Click Install</a>)
 This script allows berries to grow while the game is closed, simulating their growth when the game loads. No mutations occur, aside from Kebia replanting, and Farm Hands are not active. Withered berries can replant as normal, but the script will ignore replanted berries to avoid lag. You can choose between three modes in the settings: 
 
 - Until ripe: Berries will only grow until they are ripe and no time will pass for already-ripe berries. The default mode.
@@ -436,14 +455,16 @@ This script allows berries to grow while the game is closed, simulating their gr
 
 <hr>
 
-<h2 id="perky-pokerus-pandemic">[Custom] Perky Pokerus Pandemic (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/perkypokeruspandemic.user.js">perkypokeruspandemic.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/perkypokeruspandemic.user.js">One-Click Install</a>)</h2>
+<a name="perky-pokerus-pandemic"></a>
+## [Custom] Perky Pokerus Pandemic (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/perkypokeruspandemic.user.js">perkypokeruspandemic.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/perkypokeruspandemic.user.js">One-Click Install</a>)
 This script makes Pokérus spread inside the Hatchery without needing your Starter Pokémon inside for this to be accomplished.
 
 This script will run and work automatically without needing to do anything else.
 
 <hr>
 
-<h2 id="simple-weather-changer">[Custom] Simple Weather Changer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/simpleweatherchanger.user.js">simpleweatherchanger.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/simpleweatherchanger.user.js">One-Click Install</a>)</h2>
+<a name="simple-weather-changer"></a>
+## [Custom] Simple Weather Changer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/master/custom/simpleweatherchanger.user.js">simpleweatherchanger.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/custom/simpleweatherchanger.user.js">One-Click Install</a>)
 This script lets you freely edit the weather of the region you are currently in with this button:<br>
 
 ![image](https://i.imgur.com/2cBIfyH.png)

--- a/additionalvisualsettings.user.js
+++ b/additionalvisualsettings.user.js
@@ -44,35 +44,8 @@ function initVisualSettings() {
         getMenu.prepend(quickElem);
     });
 
-    var scriptSettings = document.getElementById('settings-scripts');
-    // Create scripts settings tab if it doesn't exist yet
-    if (!scriptSettings) {
-        // Fixes the Scripts nav item getting wrapped to the bottom by increasing the max width of the window
-        document.getElementById('settingsModal').querySelector('div').style.maxWidth = '850px';
-        // Create and attach script settings tab link
-        const settingTabs = document.querySelector('#settingsModal ul.nav-tabs');
-        let li = document.createElement('li');
-        li.classList.add('nav-item');
-        li.innerHTML = `<a class="nav-link" href="#settings-scripts" data-toggle="tab">Scripts</a>`;
-        settingTabs.appendChild(li);
-        // Create and attach script settings tab contents
-        const tabContent = document.querySelector('#settingsModal .tab-content');
-        scriptSettings = document.createElement('div');
-        scriptSettings.classList.add('tab-pane');
-        scriptSettings.setAttribute('id', 'settings-scripts');
-        tabContent.appendChild(scriptSettings);
-    }
-
     // Add AVS settings options to scripts tab
-    let table = document.createElement('table');
-    table.classList.add('table', 'table-striped', 'table-hover', 'm-0');
-    scriptSettings.prepend(table);
-    let header = document.createElement('thead');
-    header.innerHTML = '<tr><th colspan="2">Additional Visual Settings</th></tr>';
-    table.appendChild(header);
-    let settingsBody = document.createElement('tbody');
-    settingsBody.setAttribute('id', 'settings-scripts-additionalvisualsettings');
-    table.appendChild(settingsBody);
+    const settingsBody = createScriptSettingsContainer('Additional Visual Settings');
     let settingsToAdd = [['poke-name', 'Show wild Pokémon Name'],
         ['poke-defeat', 'Show wild Pokémon Defeated'],
         ['poke-image', 'Show wild Pokémon Image'],
@@ -375,6 +348,56 @@ function loadSetting(key, defaultVal) {
         localStorage.setItem(key, defaultVal);
     }
     return val;
+}
+
+/**
+ * Creates container for scripts settings in the settings menu, adding scripts tab if it doesn't exist yet
+ */
+function createScriptSettingsContainer(name) {
+    const settingsID = name.replaceAll(/s/g, '').toLowerCase();
+    var settingsContainer = document.getElementById('settings-scripts-container');
+
+    // Create scripts settings tab if it doesn't exist yet
+    if (!settingsContainer) {
+        // Fixes the Scripts nav item getting wrapped to the bottom by increasing the max width of the window
+        document.querySelector('#settingsModal div').style.maxWidth = '850px';
+        // Create and attach script settings tab link
+        const settingTabs = document.querySelector('#settingsModal ul.nav-tabs');
+        const li = document.createElement('li');
+        li.classList.add('nav-item');
+        li.innerHTML = `<a class="nav-link" href="#settings-scripts" data-toggle="tab">Scripts</a>`;
+        settingTabs.appendChild(li);
+        // Create and attach script settings tab contents
+        const tabContent = document.querySelector('#settingsModal .tab-content');
+        scriptSettings = document.createElement('div');
+        scriptSettings.classList.add('tab-pane');
+        scriptSettings.setAttribute('id', 'settings-scripts');
+        tabContent.appendChild(scriptSettings);
+        settingsContainer = document.createElement('div');
+        settingsContainer.setAttribute('id', 'settings-scripts-container');
+        scriptSettings.appendChild(settingsContainer);
+    }
+
+    // Create settings container
+    const settingsTable = document.createElement('table');
+    settingsTable.classList.add('table', 'table-striped', 'table-hover', 'm-0');
+    const header = document.createElement('thead');
+    header.innerHTML = `<tr><th colspan="2">${name}</th></tr>`;
+    settingsTable.appendChild(header);
+    const settingsBody = document.createElement('tbody');
+    settingsBody.setAttribute('id', `settings-scripts-${settingsID}`);
+    settingsTable.appendChild(settingsBody);
+
+    // Insert settings container in alphabetical order
+    let settingsList = Array.from(settingsContainer.children);
+    let insertBefore = settingsList.find(elem => elem.querySelector('tbody').id > `settings-scripts-${settingsID}`);
+    if (insertBefore) {
+        insertBefore.before(settingsTable);
+    } else {
+        settingsContainer.appendChild(settingsTable);
+    }
+
+    return settingsBody;
 }
 
 function loadScript(){

--- a/additionalvisualsettings.user.js
+++ b/additionalvisualsettings.user.js
@@ -5,7 +5,7 @@
 // @description   Adds additional settings for hiding some visual things to help out with performance. Also, includes various features that help with ease of accessibility.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       2.5
+// @version       2.6
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -203,7 +203,7 @@ function initVisualSettings() {
         const fragment = new DocumentFragment();
         const regionGyms = Object.values(GymList).filter((gym) => gym.parent?.region === player.region);
         for (const gym of regionGyms) {
-            const hasBadgeImage = !BadgeEnums[gym.badgeReward].startsWith('Elite') && BadgeEnums[gym.badgeReward] != 'None';
+            const hasBadgeImage = !(BadgeEnums[gym.badgeReward].startsWith('Elite') || BadgeEnums[gym.badgeReward] == 'None');
             const badgeImage = (hasBadgeImage ? `assets/images/badges/${BadgeEnums[gym.badgeReward]}.png` : '');
             const btn = document.createElement('button');
             btn.setAttribute('style', 'position: relative;');
@@ -215,9 +215,9 @@ function initVisualSettings() {
                 $("#gymsShortcutModal").modal("hide");
                 GymRunner.startGym(gym); 
             });
-            btn.disabled = !(gym.isUnlocked() && MapHelper.calculateTownCssClass(gym.parent.name));
+            btn.disabled = !(gym.isUnlocked() && gym.parent.isUnlocked());
             btn.innerHTML = `<div class="gyms-shortcut-leaders">
-                <img src="assets/images/gymLeaders/${gym.leaderName}.png" onerror="{ this.onerror=null; this.style.display='none'; }">
+                <img src="${gym.imagePath}" onerror="{ this.src='assets/images/npcs/specialNPCs/Mysterious Trainer.png'; }">
                 </div>
                 <div class="gyms-shortcut-badges">
                 <img src="${badgeImage}" onerror="{ this.onerror=null; this.style.display='none'; }">

--- a/additionalvisualsettings.user.js
+++ b/additionalvisualsettings.user.js
@@ -115,6 +115,10 @@ function initVisualSettings() {
         document.getElementById('townMap').appendChild(button);
     });
 
+    // Prevent ship modal sequence-breaking
+    document.getElementById('dock-button').setAttribute('data-bind', 'enabled: TownList[GameConstants.DockTowns[player.region]].isUnlocked()');
+    ko.applyBindings(App.game, document.getElementById('dock-button'));
+
     // Create gym and dungeon shortcut modals
     const modalNames = ['gyms', 'dungeons'];
     const fragment = new DocumentFragment();

--- a/autobattlefrontier.user.js
+++ b/autobattlefrontier.user.js
@@ -42,9 +42,6 @@ class AutoBattleFrontier {
     }
 
     static initAutoBattleFrontier() {
-        // Necessary for userscript managers
-        window.AutoBattleFrontier = AutoBattleFrontier;
-
         AutoBattleFrontier.overrideGameMethods();
 
         const bfStart = document.querySelector('#battleFrontierInformation a[onclick="BattleFrontierRunner.start(false)"]');
@@ -157,6 +154,10 @@ class AutoBattleFrontier {
 }
 
 function loadScript() {
+    if (!App.isUsingClient) {
+        // Necessary for userscript managers
+        unsafeWindow.AutoBattleFrontier = AutoBattleFrontier;
+    }
     AutoBattleFrontier.initAutoBattleFrontier();
 }
 

--- a/autobattlefrontier.user.js
+++ b/autobattlefrontier.user.js
@@ -14,7 +14,7 @@
 
 // @match         https://www.pokeclicker.com/
 // @icon          https://www.google.com/s2/favicons?domain=pokeclicker.com
-// @grant         none
+// @grant         unsafeWindow
 // @run-at        document-idle
 // ==/UserScript==
 

--- a/custom/autoquestcompleter.user.js
+++ b/custom/autoquestcompleter.user.js
@@ -65,37 +65,9 @@ function initAutoQuest() {
         questResetBtn.textContent = `${questResetTimer} minute Reset Timer [${questResetState ? 'ON' : 'OFF'}]`;
         questResetBtn.addEventListener('click', () => { toggleQuestResetState(); });
         document.getElementById('questDisplayContainer').appendChild(questResetBtn);
-        
-        // Settings tab options
-        var scriptSettings = document.getElementById('settings-scripts');
-        // Create scripts settings tab if it doesn't exist yet
-        if (!scriptSettings) {
-            // Fixes the Scripts nav item getting wrapped to the bottom by increasing the max width of the window
-            document.getElementById('settingsModal').querySelector('div').style.maxWidth = '850px';
-            // Create and attach script settings tab link
-            const settingTabs = document.querySelector('#settingsModal ul.nav-tabs');
-            let li = document.createElement('li');
-            li.classList.add('nav-item');
-            li.innerHTML = `<a class="nav-link" href="#settings-scripts" data-toggle="tab">Scripts</a>`;
-            settingTabs.appendChild(li);
-            // Create and attach script settings tab contents
-            const tabContent = document.querySelector('#settingsModal .tab-content');
-            scriptSettings = document.createElement('div');
-            scriptSettings.classList.add('tab-pane');
-            scriptSettings.setAttribute('id', 'settings-scripts');
-            tabContent.appendChild(scriptSettings);
-        }
 
         // Add settings to scripts tab
-        let table = document.createElement('table');
-        table.classList.add('table', 'table-striped', 'table-hover', 'm-0');
-        scriptSettings.prepend(table);
-        let header = document.createElement('thead');
-        header.innerHTML = '<tr><th colspan="2">Auto Quest Completer</th></tr>';
-        table.appendChild(header);
-        let settingsBody = document.createElement('tbody');
-        settingsBody.setAttribute('id', 'settings-scripts-autoquestcompleter');
-        table.appendChild(settingsBody);
+        const settingsBody = createScriptSettingsContainer('Auto Quest Completer');
         let maxQuestsElem = document.createElement('tr');
         maxQuestsElem.innerHTML = `<td class="p-2 col-md-8">Max quest slots</td><td class="p-0 col-md-4"><select id="select-autoQuestMaxQuests" class="form-control">` +
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => `<option value="${i}">${i}</option>`).join('\n') + `</select></td>`;
@@ -296,7 +268,57 @@ function loadSetting(key, defaultVal) {
     return val;
 }
 
-function loadScript(){
+/**
+ * Creates container for scripts settings in the settings menu, adding scripts tab if it doesn't exist yet
+ */
+function createScriptSettingsContainer(name) {
+    const settingsID = name.replaceAll(/s/g, '').toLowerCase();
+    var settingsContainer = document.getElementById('settings-scripts-container');
+
+    // Create scripts settings tab if it doesn't exist yet
+    if (!settingsContainer) {
+        // Fixes the Scripts nav item getting wrapped to the bottom by increasing the max width of the window
+        document.querySelector('#settingsModal div').style.maxWidth = '850px';
+        // Create and attach script settings tab link
+        const settingTabs = document.querySelector('#settingsModal ul.nav-tabs');
+        const li = document.createElement('li');
+        li.classList.add('nav-item');
+        li.innerHTML = `<a class="nav-link" href="#settings-scripts" data-toggle="tab">Scripts</a>`;
+        settingTabs.appendChild(li);
+        // Create and attach script settings tab contents
+        const tabContent = document.querySelector('#settingsModal .tab-content');
+        scriptSettings = document.createElement('div');
+        scriptSettings.classList.add('tab-pane');
+        scriptSettings.setAttribute('id', 'settings-scripts');
+        tabContent.appendChild(scriptSettings);
+        settingsContainer = document.createElement('div');
+        settingsContainer.setAttribute('id', 'settings-scripts-container');
+        scriptSettings.appendChild(settingsContainer);
+    }
+
+    // Create settings container
+    const settingsTable = document.createElement('table');
+    settingsTable.classList.add('table', 'table-striped', 'table-hover', 'm-0');
+    const header = document.createElement('thead');
+    header.innerHTML = `<tr><th colspan="2">${name}</th></tr>`;
+    settingsTable.appendChild(header);
+    const settingsBody = document.createElement('tbody');
+    settingsBody.setAttribute('id', `settings-scripts-${settingsID}`);
+    settingsTable.appendChild(settingsBody);
+
+    // Insert settings container in alphabetical order
+    let settingsList = Array.from(settingsContainer.children);
+    let insertBefore = settingsList.find(elem => elem.querySelector('tbody').id > `settings-scripts-${settingsID}`);
+    if (insertBefore) {
+        insertBefore.before(settingsTable);
+    } else {
+        settingsContainer.appendChild(settingsTable);
+    }
+
+    return settingsBody;
+}
+
+function loadScript() {
     const oldInit = Preload.hideSplashScreen;
     var hasInitialized = false;
 

--- a/custom/autosafarizone.user.js
+++ b/custom/autosafarizone.user.js
@@ -8,7 +8,7 @@
 // @description   Adds in toggable options to move/catch pokemons/pick up items and have fast animations on both safari zones
 // @copyright     https://github.com/Kanzen01
 // @license       GPL-3.0 License
-// @version       1.0
+// @version       1.1
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -197,39 +197,46 @@ function initAutoSafari() {
 
     var chosenTiles;
 
-    // When prioritizing certain spawns, seek the tile type with the highest chance of priority spawns
+    // When prioritizing certain spawns, seek encounter tiles based on what will complete our goal fastest, i.e.:
+    //   - if environments either share all priority spawns or both have unique priority spawns, seek the one with highest priority chance
+    //   - if one environment's priority spawns are a proper subset of the other, seek the one with more spawns
     if ((autoSafariSeekUncaught || autoSafariSeekContagious) && hasPrioritySpawns > -1) {
       if (hasPrioritySpawns == 0) {
         let grassPriorityWeight = 0;
         let waterPriorityWeight = 0;
         let grassTotalWeight = 0;
         let waterTotalWeight = 0;
+        let grassDisjointPriority = false;
+        let waterDisjointPriority = false;
 
         SafariPokemonList.list[player.region]().forEach((p) => {
-          if (p.environments.includes(SafariEnvironments.Grass)) {
-            grassTotalWeight += p.weight;
-          }
-          if (p.environments.includes(SafariEnvironments.Water)) {
-            waterTotalWeight += p.weight;
-          }
+          let isGrass = p.environments.includes(SafariEnvironments.Grass);
+          let isWater = p.environments.includes(SafariEnvironments.Water);
+          grassTotalWeight += isGrass * p.weight;
+          waterTotalWeight += isWater * p.weight;
           if (isPriority(p.name)) {
-            if (p.environments.includes(SafariEnvironments.Grass)) {
-              grassPriorityWeight += p.weight;
-            }
-            if (p.environments.includes(SafariEnvironments.Water)) {
-              waterPriorityWeight += p.weight;
+            grassPriorityWeight += isGrass * p.weight;
+            waterPriorityWeight += isWater * p.weight;
+            if (!(isGrass && isWater)) {
+              grassDisjointPriority ||= isGrass;
+              waterDisjointPriority ||= isWater;
             }
           }
         });
 
-        let grassPriorityChance = grassPriorityWeight / grassTotalWeight;
-        let waterPriorityChance = waterPriorityWeight / waterTotalWeight;
-        if (grassPriorityChance == waterPriorityChance) {
-          cachedPriorityEnvironments = [GameConstants.SafariTile.grass, ...GameConstants.SAFARI_WATER_BLOCKS];
-        } else if (grassPriorityChance > waterPriorityChance) {
-          cachedPriorityEnvironments = [GameConstants.SafariTile.grass];
-        } else {
-          cachedPriorityEnvironments = [...GameConstants.SAFARI_WATER_BLOCKS];
+        // Identical priority pools or unique priority spawns, decide by priotity spawn chance
+        if (grassDisjointPriority == waterDisjointPriority) {
+          let grassPriorityChance = grassPriorityWeight / grassTotalWeight;
+          let waterPriorityChance = waterPriorityWeight / waterTotalWeight;
+          if (grassPriorityChance == waterPriorityChance) {
+            cachedPriorityEnvironments = [GameConstants.SafariTile.grass, ...GameConstants.SAFARI_WATER_BLOCKS];
+          } else {
+            cachedPriorityEnvironments = grassPriorityChance > waterPriorityChance ? [GameConstants.SafariTile.grass] : [...GameConstants.SAFARI_WATER_BLOCKS];
+          }
+        }
+        // One priority pool contains the other, go there
+        else {
+          cachedPriorityEnvironments = grassDisjointPriority ? [GameConstants.SafariTile.grass] : [...GameConstants.SAFARI_WATER_BLOCKS];
         }
 
         hasPrioritySpawns = (grassPriorityWeight == 0 && waterPriorityWeight == 0) ? -1 : 1;
@@ -306,8 +313,7 @@ function initAutoSafari() {
 
         // TODO remove SAFARI_WATER_BLOCKS after game update makes it redundant
         if (isValidPosition(nextRow, nextCol) && !visited.has(nextPosStr)
-          && (GameConstants.SAFARI_LEGAL_WALK_BLOCKS.includes(Safari.grid[nextRow][nextCol])
-            || GameConstants.SAFARI_WATER_BLOCKS.includes(Safari.grid[nextRow][nextCol]))
+          && (GameConstants.SAFARI_LEGAL_WALK_BLOCKS.includes(Safari.grid[nextRow][nextCol]))
         ) {
           {
             const nextPath = currentPath.concat([direction]);

--- a/custom/autosafarizone.user.js
+++ b/custom/autosafarizone.user.js
@@ -99,7 +99,7 @@ function initAutoSafari() {
   }
 
   function enterSafari() {
-    if (!(Safari.canAccess() && !player.route() && ['Safari Zone', 'Friend Safari'].includes(player.town().name))) {
+    if (!(Safari.canAccess() && !player.route() && ['Safari Zone', 'National Park', 'Great Marsh', 'Friend Safari'].includes(player.town().name))) {
       // Safari inaccessible from here
       toggleAutoSafari();
       return;

--- a/custom/autosafarizone.user.js
+++ b/custom/autosafarizone.user.js
@@ -120,7 +120,7 @@ function initAutoSafari() {
   }
 
   function enterSafari() {
-    if (!(Safari.canAccess() && !player.route() && ['Safari Zone', 'National Park', 'Great Marsh', 'Friend Safari'].includes(player.town().name))) {
+    if (!(Safari.canAccess() && !player.route() && player.town().content.some(c => c.constructor.name === 'SafariTownContent'))) {
       // Safari inaccessible from here
       toggleAutoSafari();
       return;

--- a/custom/autosafarizone.user.js
+++ b/custom/autosafarizone.user.js
@@ -8,7 +8,7 @@
 // @description   Adds in toggable options to move/catch pokemons/pick up items and have fast animations on both safari zones
 // @copyright     https://github.com/Kanzen01
 // @license       GPL-3.0 License
-// @version       1.1
+// @version       1.1.1
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -230,7 +230,7 @@ function initAutoSafari() {
         let grassDisjointPriority = false;
         let waterDisjointPriority = false;
 
-        SafariPokemonList.list[player.region]().forEach((p) => {
+        SafariPokemonList.list[player.region]().filter((p) => p.isAvailable()).forEach((p) => {
           let isGrass = p.environments.includes(SafariEnvironments.Grass);
           let isWater = p.environments.includes(SafariEnvironments.Water);
           grassTotalWeight += isGrass * p.weight;

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -23,7 +23,7 @@ A version of the PokéClicker desktop client modified to manage and run userscr
 
 Optionally, you can add custom scripts from outside this project. This mod creates two new folders in the app's application data directory, `scripts` and `custom-scripts`. JavaScript (`.js`) files placed in the `custom-scripts` folder will run when the app is launched, and like other scripts can be disabled/enabled in the settings. The application data location depends on operating system:
 
-- Windows: `%APPDATA%/pokeclicker-desktop`
+- Windows: `%appdata%/pokeclicker-desktop` or `%localappdata%/pokeclicker-desktop`
 - macOS: `~/Library/Application Support/pokeclicker-desktop`
 - Linux: either `$XDG_CONFIG_HOME/pokeclicker-desktop` or `~/.config/pokeclicker-desktop`
 

--- a/desktop/app_src/src/main.js
+++ b/desktop/app_src/src/main.js
@@ -47,7 +47,8 @@ function createWindow() {
 
   if (fs.existsSync(settingsFile)) {
     getConfig();
-  } else {
+  }
+  if (!(config?.Sizing && +config.Sizing.Width && +config.Sizing.Height && typeof config.Sizing.Maximized === 'boolean')) {
     config = { Sizing: { Width: "800", Height: "600", Maximized: false } };
     fs.writeFile(
       settingsFile,

--- a/desktop/app_src/src/main.js
+++ b/desktop/app_src/src/main.js
@@ -468,7 +468,7 @@ Ephenia scripts loading
 */
 
 // VERY IMPORTANT: update this in desktopupdatechecker.js as well!
-const POKECLICKER_SCRIPTS_DESKTOP_VERSION = '2.0.3';
+const POKECLICKER_SCRIPTS_DESKTOP_VERSION = '2.0.4';
 
 function logInMainWindow(message, level = 'log') {
   if (message == null) {
@@ -486,7 +486,7 @@ function runScript(scriptFilePath) {
     if (fs.existsSync(scriptFilePath)) {
       logInMainWindow(`Running ${scriptFilePath}`, 'debug');
       mainWindow.webContents
-        .executeJavaScript(fs.readFileSync(scriptFilePath, 'utf-8'))
+        .executeJavaScript(fs.readFileSync(scriptFilePath, 'utf-8') + ';0')
         .catch((err) => {
           logInMainWindow(`Issue running script '${scriptFilePath}':\n${err}`, 'error');
         })

--- a/desktop/app_src/src/scripthandler.js
+++ b/desktop/app_src/src/scripthandler.js
@@ -110,13 +110,18 @@ class DesktopScriptHandler {
         const tabContent = document.querySelector('#settingsModal .tab-content');
 
         // Create and append the content for the script tab to Settings
-        let div = document.createElement('div');
-        div.classList.add('tab-pane');
-        div.setAttribute('id', 'settings-scripts');
+        const scriptSettings = document.createElement('div');
+        scriptSettings.classList.add('tab-pane');
+        scriptSettings.setAttribute('id', 'settings-scripts');
+        tabContent.appendChild(scriptSettings);
+
+        let settingsContainer = document.createElement('div');
+        settingsContainer.setAttribute('id', 'settings-scripts-container');
+        scriptSettings.appendChild(settingsContainer);
 
         let table = document.createElement('table');
         table.classList.add('table', 'table-striped', 'table-hover', 'm-0');
-        div.appendChild(table);
+        scriptSettings.appendChild(table);
 
         let tableSections = [['desktopSettings', 'Pokéclicker Scripts desktop settings'],
             ['enableScriptsEphenia', 'Downloaded scripts'],
@@ -130,8 +135,6 @@ class DesktopScriptHandler {
             elem.setAttribute('id', 'settings-scripts-' + id);
             table.appendChild(elem);
         });
-
-        tabContent.appendChild(div);
 
         // Add info about restarting to the top
         let info = document.createElement('tr');

--- a/desktopupdatechecker.js
+++ b/desktopupdatechecker.js
@@ -2,7 +2,7 @@
 
 {
 	// IMPORTANT: Always keep this up to date with the version number in app_src/main.js
-	const LATEST_VERSION = '2.0.3';
+	const LATEST_VERSION = '2.0.4';
 
 	if (App.isUsingClient) {
 		if (typeof POKECLICKER_SCRIPTS_DESKTOP_VERSION !== 'string' 

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -14,7 +14,7 @@
 
 // @match         https://www.pokeclicker.com/
 // @icon          https://www.google.com/s2/favicons?domain=pokeclicker.com
-// @grant         none
+// @grant         unsafeWindow
 // @run-at        document-idle
 // ==/UserScript==
 

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -174,7 +174,7 @@ class EnhancedAutoClicker {
         });
         // Checkboxes
         let checkboxesToAdd = [
-            ['autoDungeonAlwaysOpenRareChests', 'Always open visible chests of set rarity and up', this.autoDungeonAlwaysOpenRareChests],
+            ['autoDungeonAlwaysOpenRareChests', 'Always open visible targeted chests', this.autoDungeonAlwaysOpenRareChests],
             ['autoGymGraphicsDisabled', 'Disable Auto Gym graphics', this.gymGraphicsDisabled()],
             ['autoDungeonGraphicsDisabled', 'Disable Auto Dungeon graphics', this.dungeonGraphicsDisabled()]
         ];

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -35,7 +35,7 @@ class EnhancedAutoClicker {
     static autoDungeonState = ko.observable(validateStorage('autoDungeonState', false));
     static autoDungeonEncounterMode = validateStorage('autoDungeonEncounterMode', false);
     static autoDungeonChestMode = validateStorage('autoDungeonChestMode', false);
-    static autoDungeonLootTier = validateStorage('autoDungeonLootTier', 0, Object.keys(baseLootTierChance).keys());
+    static autoDungeonLootTier = validateStorage('autoDungeonLootTier', 0, [...Object.keys(baseLootTierChance).keys()]);
     static autoDungeonAlwaysOpenRareChests = validateStorage('autoDungeonAlwaysOpenRareChests', false);
     static autoDungeonTracker = {
         ID: 0,
@@ -335,7 +335,7 @@ class EnhancedAutoClicker {
 
     static changeAutoDungeonLootTier(tier) {
         const val = +tier;
-        if (Object.keys(baseLootTierChance).keys().includes(val)) {
+        if ([...Object.keys(baseLootTierChance).keys()].includes(val)) {
             this.autoDungeonLootTier = val;
             document.getElementById('auto-dungeon-loottier-img').setAttribute('src', `assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[val]}.png`);
             localStorage.setItem("autoDungeonLootTier", this.autoDungeonLootTier);

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -19,235 +19,1059 @@
 // ==/UserScript==
 
 var scriptName = 'enhancedautoclicker';
-const ticksPerSecond = 20;
-const maxClickMultiplier = 5;
-// Auto Clicker
-var autoClickState = ko.observable(false);
-var autoClickMultiplier;
-var autoClickerLoop;
-// Auto Gym
-var autoGymState = ko.observable(false);
-var autoGymSelect;
-// Auto Dungeon
-var autoDungeonState = ko.observable(false);
-var autoDungeonEncounterMode;
-var autoDungeonChestMode;
-var autoDungeonLootTier;
-var autoDungeonAlwaysOpenRareChests;
-var autoDungeonTracker = {
-    ID: 0,
-    floor: null,
-    floorSize: null,
-    flashTier: null,
-    flashCols: null,
-    flashPatterns: {'-1': [[0, 0]],
-        '0': [[-1, 0], [0, -1], [1, 0]],
-        '1': [[-1, 0], [-1, -1], [0, -1], [1, -1], [1, 0]],
-        '2': [[-2, 0], [-1, -1], [0, -2], [1, -1], [2, 0]],
-    },
-    coords: null,
-    bossCoords: null,
-    encounterCoords: null,
-    chestCoords: null,
-    floorExplored: false,
-    floorFinished: false,
-};
-// Clicker statistics calculator
-var autoClickCalcLoop;
-var autoClickCalcEfficiencyDisplayMode;
-var autoClickCalcDamageDisplayMode;
-var autoClickCalcTracker = {
-    lastUpdate: null,
-    playerState: -1,
-    playerLocation: null,
-    ticks: null,
-    clicks: null,
-    enemies: null,
-    areaHealth: null,
-};
-// Visual settings
-var gymGraphicsDisabled = ko.observable(false);
-var dungeonGraphicsDisabled = ko.observable(false);
 
-/* Initialization */
-
-function initAutoClicker() {
-    const battleView = document.getElementsByClassName('battle-view')[0];
-
-    var elemAC = document.createElement("table");
-    elemAC.innerHTML = `<tbody>
-    <tr>
-        <td colspan="4">
-            <button id="auto-click-start" class="btn btn-${autoClickState() ? 'success' : 'danger'} btn-block" style="font-size:8pt;">
-                Auto Click [${autoClickState() ? 'ON' : 'OFF'}]<br />
-                <div id="auto-click-info">
-                    <!-- calculator display will be set by resetCalculator() -->
-                </div>
-            </button>
-            <div id="click-rate-cont">
-                <div id="auto-click-rate-info">
-                    Click Attack Rate: ${(ticksPerSecond * autoClickMultiplier).toLocaleString('en-US', {maximumFractionDigits: 2})}/s
-                </div>
-                <input id="auto-click-rate" type="range" min="1" max="${maxClickMultiplier}" value="${autoClickMultiplier}">
-            </div>
-        </td>
-    </tr>
-    <tr>
-        <td style="display: flex; column-gap: 2px;">
-            <div style="flex: auto;">
-                <button id="auto-dungeon-start" class="btn btn-block btn-${autoDungeonState() ? 'success' : 'danger'}" style="font-size: 8pt;">
-                    Auto Dungeon [${autoDungeonState() ? 'ON' : 'OFF'}]
-                </button>
-            </div>
-            <div id="auto-dungeon-encounter-mode" style="flex: initial; max-height: 30px; max-width: 30px; padding: 2px;">
-                <img title="Auto Dungeon fights mode" src="assets/images/dungeons/encounter.png" height="100%" style="${autoDungeonEncounterMode ? '' : 'filter: grayscale(100%);'}" />
-            </div>
-            <div id="auto-dungeon-chest-mode" style="flex: initial; max-height: 30px; max-width: 40px; padding: 2px;">
-                <img title="Auto Dungeon chest mode" src="assets/images/dungeons/chest.png" height="100%" style="${autoDungeonChestMode ? '' : 'filter: grayscale(100%)'}" />
-            </div>
-            <div style="flex: initial; display: flex; flex-direction: column;">
-                <div id="auto-dungeon-loottier" class="dropdown show">
-                    <button type="button" class="text-left custom-select col-12 btn btn-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="max-height:30px; display:flex; flex:1; align-items:center;">
-                        <div id="auto-dungeon-loottier-text" ${autoDungeonLootTier > -1 ? 'style="display:none;"' : ''}>None</div>
-                        <img id="auto-dungeon-loottier-img" src="${autoDungeonLootTier > -1 ? `assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[autoDungeonLootTier]}.png` : ''}" style="height:100%; ${autoDungeonLootTier > -1 ? '' : 'display:none;'}">
-                    </button>
-                    <div id="auto-dungeon-loottier-dropdown" class="border-secondary dropdown-menu col-12">
-                        <div class="dropdown-item dropdown-text" value="-1">None</div>
-                        ${Object.keys(baseLootTierChance).reduce((options, tier, i) => {
-                            return options + `<div class="dropdown-item" value="${i}">`
-                                + `<img src="assets/images/dungeons/chest-${tier}.png"></div>\n`;
-                        }, '').trim()}
-                    </div>
-                </div>
-            </div>
-            <div style="flex: auto; margin-right: 2px;">
-                <button id="auto-gym-start" class="btn btn-block btn-${autoGymState() ? 'success' : 'danger'}" style="font-size: 8pt;">
-                    Auto Gym [${autoGymState() ? 'ON' : 'OFF'}]
-                </button>
-            </div>
-            <div style="flex: initial; display: flex; flex-direction: column;">
-                <select id="auto-gym-select" style="flex: auto;">
-                    <option value="0">#1</option>
-                    <option value="1">#2</option>
-                    <option value="2">#3</option>
-                    <option value="3">#4</option>
-                    <option value="4">#5</option>
-                </select>
-            </div>
-        </td>
-    </tr>
-    </tbody>`;
-
-    battleView.before(elemAC);
-    resetCalculator(); // initializes calculator display
-
-    var scriptSettings = document.getElementById('settings-scripts');
-    // Create scripts settings tab if it doesn't exist yet
-    if (!scriptSettings) {
-        // Fixes the Scripts nav item getting wrapped to the bottom by increasing the max width of the window
-        document.getElementById('settingsModal').querySelector('div').style.maxWidth = '850px';
-        // Create and attach script settings tab link
-        const settingTabs = document.querySelector('#settingsModal ul.nav-tabs');
-        let li = document.createElement('li');
-        li.classList.add('nav-item');
-        li.innerHTML = `<a class="nav-link" href="#settings-scripts" data-toggle="tab">Scripts</a>`;
-        settingTabs.appendChild(li);
-        // Create and attach script settings tab contents
-        const tabContent = document.querySelector('#settingsModal .tab-content');
-        scriptSettings = document.createElement('div');
-        scriptSettings.classList.add('tab-pane');
-        scriptSettings.setAttribute('id', 'settings-scripts');
-        tabContent.appendChild(scriptSettings);
-    }
-
-    let table = document.createElement('table');
-    table.classList.add('table', 'table-striped', 'table-hover', 'm-0');
-    scriptSettings.prepend(table);
-    let header = document.createElement('thead');
-    header.innerHTML = '<tr><th colspan="2">Enhanced Auto Clicker</th></tr>';
-    table.appendChild(header);
-    let settingsBody = document.createElement('tbody');
-    settingsBody.setAttribute('id', 'settings-scripts-enhancedautoclicker');
-    table.appendChild(settingsBody);
-
-    var settingsElems = [];
-    settingsElems.push(document.createElement('tr'));
-    settingsElems.at(-1).innerHTML = `<td class="p-2 col-md-8">
-        Auto Clicker efficiency display mode
-        </td>
-        <td class="p-0 col-md-4">
-        <select id="select-autoClickCalcEfficiencyDisplayMode" class="form-control">
-        <option value="0">Percentage</option>
-        <option value="1">Ticks/s</option>
-        </select>
-        </td>`;
-    settingsElems.push(document.createElement('tr'));
-    settingsElems.at(-1).innerHTML = `<td class="p-2 col-md-8">
-        Auto Clicker damage display mode
-        </td>
-        <td class="p-0 col-md-4">
-        <select id="select-autoClickCalcDamageDisplayMode" class="form-control">
-        <option value="0">Click Attacks</option>
-        <option value="1">Damage</option>
-        </select>
-        </td>`;
-    settingsElems.push(document.createElement('tr'));
-    settingsElems.at(-1).innerHTML = `<td class="p-2 col-md-8">
-        <label class="m-0" for="checkbox-autoDungeonAlwaysOpenRareChests">Always open visible chests of set rarity and up</label>
-        </td><td class="p-2 col-md-4">
-        <input id="checkbox-autoDungeonAlwaysOpenRareChests" type="checkbox">
-        </td>`;
-    settingsElems.push(document.createElement('tr'));
-    settingsElems.at(-1).innerHTML = `<td class="p-2 col-md-8">
-        <label class="m-0" for="checkbox-autoGymGraphicsDisabled">Disable Auto Gym graphics</label>
-        </td><td class="p-2 col-md-4">
-        <input id="checkbox-autoGymGraphicsDisabled" type="checkbox">
-        </td>`;
-    settingsElems.push(document.createElement('tr'));
-    settingsElems.at(-1).innerHTML = `<td class="p-2 col-md-8">
-        <label class="m-0" for="checkbox-autoDungeonGraphicsDisabled">Disable Auto Dungeon graphics</label>
-        </td><td class="p-2 col-md-4">
-        <input id="checkbox-autoDungeonGraphicsDisabled" type="checkbox">
-        </td>`;
-
-    settingsBody.append(...settingsElems);
-
-    document.getElementById('auto-gym-select').value = autoGymSelect;
-    //document.getElementById('auto-dungeon-encounter-mode').checked = autoDungeonEncounterMode;
-    //document.getElementById('auto-dungeon-chest-mode').checked = autoDungeonChestMode;
-    document.getElementById('checkbox-autoDungeonAlwaysOpenRareChests').checked = autoDungeonAlwaysOpenRareChests;
-    document.getElementById('checkbox-autoGymGraphicsDisabled').checked = gymGraphicsDisabled();
-    document.getElementById('checkbox-autoDungeonGraphicsDisabled').checked = dungeonGraphicsDisabled();
-    document.getElementById('select-autoClickCalcEfficiencyDisplayMode').value = autoClickCalcEfficiencyDisplayMode;
-    document.getElementById('select-autoClickCalcDamageDisplayMode').value = autoClickCalcDamageDisplayMode;
-
-    document.getElementById('auto-click-start').addEventListener('click', () => { toggleAutoClick(); });
-    document.getElementById('auto-click-rate').addEventListener('change', (event) => { changeClickMultiplier(event); });
-    document.getElementById('auto-gym-start').addEventListener('click', () => { toggleAutoGym(); });
-    document.getElementById('auto-gym-select').addEventListener('change', (event) => { changeSelectedGym(event); });
-    document.getElementById('auto-dungeon-start').addEventListener('click', () => { toggleAutoDungeon(); });
-    document.getElementById('auto-dungeon-encounter-mode').addEventListener('click', () => { toggleAutoDungeonEncounterMode(); });
-    document.getElementById('auto-dungeon-chest-mode').addEventListener('click', () => { toggleAutoDungeonChestMode(); });
-    document.getElementById('checkbox-autoDungeonAlwaysOpenRareChests').addEventListener('change', () => { toggleAutoDungeonAlwaysOpenRareChests(); });
-    document.getElementById('checkbox-autoGymGraphicsDisabled').addEventListener('change', () => { toggleAutoGymGraphics(); });
-    document.getElementById('checkbox-autoDungeonGraphicsDisabled').addEventListener('change', () => { toggleAutoDungeonGraphics(); });
-    document.getElementById('select-autoClickCalcEfficiencyDisplayMode').addEventListener('change', (event) => { changeCalcEfficiencyDisplayMode(event); });
-    document.getElementById('select-autoClickCalcDamageDisplayMode').addEventListener('change', (event) => { changeCalcDamageDisplayMode(event); });
-
-    document.querySelectorAll('#auto-dungeon-loottier-dropdown > div').forEach((elem) => {
-        elem.addEventListener('click', () => { changeAutoDungeonLootTier(elem.getAttribute('value')); });
+class EnhancedAutoClicker {
+    // Constants
+    static ticksPerSecond = 20;
+    static maxClickMultiplier = 5;
+    // Auto Clicker
+    static autoClickState = ko.observable(validateStorage('autoClickState', false));
+    static autoClickMultiplier = validateStorage('autoClickMultiplier', 1, (v) => (Number.isInteger(v) && v >= 1));
+    static autoClickerLoop;
+    // Auto Gym
+    static autoGymState = ko.observable(validateStorage('autoGymState', false));
+    static autoGymSelect = validateStorage('autoGymSelect', 0, [0, 1, 2, 3, 4]);
+    // Auto Dungeon
+    static autoDungeonState = ko.observable(validateStorage('autoDungeonState', false));
+    static autoDungeonEncounterMode = validateStorage('autoDungeonEncounterMode', false);
+    static autoDungeonChestMode = validateStorage('autoDungeonEncounterMode', false);
+    static autoDungeonLootTier = validateStorage('autoDungeonLootTier', -1, [-1, ...Object.keys(baseLootTierChance).keys()]);
+    static autoDungeonAlwaysOpenRareChests = validateStorage('autoDungeonAlwaysOpenRareChests', false);
+    static autoDungeonTracker = {
+        ID: 0,
+        floor: null,
+        floorSize: null,
+        flashTier: null,
+        flashCols: null,
+        coords: null,
+        bossCoords: null,
+        encounterCoords: null,
+        chestCoords: null,
+        floorExplored: false,
+        floorFinished: false,
+    };
+    // Clicker statistics calculator
+    static autoClickCalcLoop;
+    static autoClickCalcEfficiencyDisplayMode = validateStorage('autoClickCalcEfficiencyDisplayMode', 0, [0, 1]);
+    static autoClickCalcDamageDisplayMode = validateStorage('autoClickCalcDamageDisplayMode', 0, [0, 1]);
+    static autoClickCalcTracker = {
+        lastUpdate: null,
+        playerState: -1,
+        playerLocation: null,
+        ticks: null,
+        clicks: null,
+        enemies: null,
+        areaHealth: null,
+    };
+    // Visual settings
+    static gymGraphicsDisabled = ko.observable(validateStorage('gymGraphicsDisabled', false));
+    static dungeonGraphicsDisabled = ko.observable(validateStorage('dungeonGraphicsDisabled', false));
+    // Computed observables for visual settings
+    static autoGymOn = ko.pureComputed(() => {
+        return this.autoClickState() && this.autoGymState();
+    });
+    static disableAutoGymGraphics = ko.pureComputed(() => {
+        return this.gymGraphicsDisabled() && this.autoGymOn();
+    });
+    static disableAutoDungeonGraphics = ko.pureComputed(() => {
+        return this.dungeonGraphicsDisabled() && this.autoClickState() && this.autoDungeonState();
     });
 
-    addGlobalStyle('#auto-click-info { display: flex; flex-direction: row; justify-content: center; }');
-    addGlobalStyle('#auto-click-info > div { width: 33.3%; }');
-    addGlobalStyle('#click-rate-cont { display: flex; flex-direction: column; align-items: stretch; }');
-    addGlobalStyle('#auto-dungeon-loottier-dropdown img { max-height: 30px; width: auto; }');
+    /* Initialization */
 
-    overrideGymRunner();
-    overrideDungeonRunner();
+    static initOverrides() {
+        // Add data bindings immediately, before the game initializes Knockout
+        this.addGraphicsBindings();
+    }
 
-    if (autoClickState()) {
-        autoClicker();
+    static initAutoClicker() {
+        const battleView = document.getElementsByClassName('battle-view')[0];
+
+        var elemAC = document.createElement("table");
+        elemAC.innerHTML = `<tbody>
+        <tr>
+            <td colspan="4">
+                <button id="auto-click-start" class="btn btn-${this.autoClickState() ? 'success' : 'danger'} btn-block" style="font-size:8pt;">
+                    Auto Click [${this.autoClickState() ? 'ON' : 'OFF'}]<br />
+                    <div id="auto-click-info">
+                        <!-- calculator display will be set by resetCalculator() -->
+                    </div>
+                </button>
+                <div id="click-rate-cont">
+                    <div id="auto-click-rate-info">
+                        Click Attack Rate: ${(this.ticksPerSecond * this.autoClickMultiplier).toLocaleString('en-US', {maximumFractionDigits: 2})}/s
+                    </div>
+                    <input id="auto-click-rate" type="range" min="1" max="${this.maxClickMultiplier}" value="${this.autoClickMultiplier}">
+                </div>
+            </td>
+        </tr>
+        <tr>
+            <td style="display: flex; column-gap: 2px;">
+                <div style="flex: auto;">
+                    <button id="auto-dungeon-start" class="btn btn-block btn-${this.autoDungeonState() ? 'success' : 'danger'}" style="font-size: 8pt;">
+                        Auto Dungeon [${this.autoDungeonState() ? 'ON' : 'OFF'}]
+                    </button>
+                </div>
+                <div id="auto-dungeon-encounter-mode" style="flex: initial; max-height: 30px; max-width: 30px; padding: 2px;">
+                    <img title="Auto Dungeon fights mode" src="assets/images/dungeons/encounter.png" height="100%" style="${this.autoDungeonEncounterMode ? '' : 'filter: grayscale(100%);'}" />
+                </div>
+                <div id="auto-dungeon-chest-mode" style="flex: initial; max-height: 30px; max-width: 40px; padding: 2px;">
+                    <img title="Auto Dungeon chest mode" src="assets/images/dungeons/chest.png" height="100%" style="${this.autoDungeonChestMode ? '' : 'filter: grayscale(100%)'}" />
+                </div>
+                <div style="flex: initial; display: flex; flex-direction: column;">
+                    <div id="auto-dungeon-loottier" class="dropdown show">
+                        <button type="button" class="text-left custom-select col-12 btn btn-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="max-height:30px; display:flex; flex:1; align-items:center;">
+                            <div id="auto-dungeon-loottier-text" ${this.autoDungeonLootTier > -1 ? 'style="display:none;"' : ''}>None</div>
+                            <img id="auto-dungeon-loottier-img" src="${this.autoDungeonLootTier > -1 ? `assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[this.autoDungeonLootTier]}.png` : ''}" style="height:100%; ${this.autoDungeonLootTier > -1 ? '' : 'display:none;'}">
+                        </button>
+                        <div id="auto-dungeon-loottier-dropdown" class="border-secondary dropdown-menu col-12">
+                            <div class="dropdown-item dropdown-text" value="-1">None</div>
+                            ${Object.keys(baseLootTierChance).map((tier, i) => `<div class="dropdown-item" value="${i}"><img src="assets/images/dungeons/chest-${tier}.png"></div>` ).join('\n')}
+                        </div>
+                    </div>
+                </div>
+                <div style="flex: auto;">
+                    <button id="auto-gym-start" class="btn btn-block btn-${this.autoGymState() ? 'success' : 'danger'}" style="font-size: 8pt;">
+                        Auto Gym [${this.autoGymState() ? 'ON' : 'OFF'}]
+                    </button>
+                </div>
+                <div style="flex: initial; display: flex; flex-direction: column;">
+                    <select id="auto-gym-select" value="${this.autoGymSelect}" style="flex: auto;">
+                        <option value="0">#1</option>
+                        <option value="1">#2</option>
+                        <option value="2">#3</option>
+                        <option value="3">#4</option>
+                        <option value="4">#5</option>
+                    </select>
+                </div>
+            </td>
+        </tr>
+        </tbody>`;
+
+        battleView.before(elemAC);
+        this.resetCalculator(); // initializes calculator display
+
+        var scriptSettings = document.getElementById('settings-scripts');
+        // Create scripts settings tab if it doesn't exist yet
+        if (!scriptSettings) {
+            // Fixes the Scripts nav item getting wrapped to the bottom by increasing the max width of the window
+            document.getElementById('settingsModal').querySelector('div').style.maxWidth = '850px';
+            // Create and attach script settings tab link
+            const settingTabs = document.querySelector('#settingsModal ul.nav-tabs');
+            let li = document.createElement('li');
+            li.classList.add('nav-item');
+            li.innerHTML = `<a class="nav-link" href="#settings-scripts" data-toggle="tab">Scripts</a>`;
+            settingTabs.appendChild(li);
+            // Create and attach script settings tab contents
+            const tabContent = document.querySelector('#settingsModal .tab-content');
+            scriptSettings = document.createElement('div');
+            scriptSettings.classList.add('tab-pane');
+            scriptSettings.setAttribute('id', 'settings-scripts');
+            tabContent.appendChild(scriptSettings);
+        }
+
+        // Add settings to scripts tab
+
+        let table = document.createElement('table');
+        table.classList.add('table', 'table-striped', 'table-hover', 'm-0');
+        scriptSettings.prepend(table);
+        let header = document.createElement('thead');
+        header.innerHTML = '<tr><th colspan="2">Enhanced Auto Clicker</th></tr>';
+        table.appendChild(header);
+        let settingsBody = document.createElement('tbody');
+        settingsBody.setAttribute('id', 'settings-scripts-enhancedautoclicker');
+        table.appendChild(settingsBody);
+
+        var settingsElems = [];
+        // Dropdowns
+        let dropdownsToAdd = [
+            ['autoClickCalcEfficiencyDisplayMode', 'Auto Clicker efficiency display mode', this.autoClickCalcEfficiencyDisplayMode, [[0, 'Percentage'], [1, 'Ticks/s']]],
+            ['autoClickCalcDamageDisplayMode', 'Auto Clicker damage display mode', this.autoClickCalcDamageDisplayMode, [[0, 'Click Attacks'], [1, 'Damage']]]
+        ];
+        dropdownsToAdd.forEach(([name, text, value, options]) => {
+            settingsElems.push(document.createElement('tr'));
+            settingsElems.at(-1).innerHTML = `<td class="p-2 col-md-8">
+                ${text}
+                </td>
+                <td class="p-0 col-md-4">
+                <select id="select-${name}" class="form-control" value="${value}">
+                ${options.map(([val, desc]) => `<option value="${val}">${desc}</option>`).join('\n')}
+                </select>
+                </td>`;
+        });
+        // Checkboxes
+        let checkboxesToAdd = [
+            ['autoDungeonAlwaysOpenRareChests', 'Always open visible chests of set rarity and up', this.autoDungeonAlwaysOpenRareChests],
+            ['autoGymGraphicsDisabled', 'Disable Auto Gym graphics', this.gymGraphicsDisabled()],
+            ['autoDungeonGraphicsDisabled', 'Disable Auto Dungeon graphics', this.dungeonGraphicsDisabled()]
+        ];
+        checkboxesToAdd.forEach(([name, text, isChecked]) => {
+            settingsElems.push(document.createElement('tr'));
+            settingsElems.at(-1).innerHTML = `<td class="p-2 col-md-8">
+                <label class="m-0" for="checkbox-${name}">${text}</label>
+                </td><td class="p-2 col-md-4">
+                <input id="checkbox-${name}" type="checkbox" checked="${isChecked}">
+                </td>`;
+        });
+
+        settingsBody.append(...settingsElems);
+
+        document.getElementById('auto-gym-select').value = this.autoGymSelect;
+
+        document.getElementById('auto-click-start').addEventListener('click', () => { EnhancedAutoClicker.toggleAutoClick(); });
+        document.getElementById('auto-click-rate').addEventListener('change', (event) => { EnhancedAutoClicker.changeClickMultiplier(event); });
+        document.getElementById('auto-gym-start').addEventListener('click', () => { EnhancedAutoClicker.toggleAutoGym(); });
+        document.getElementById('auto-gym-select').addEventListener('change', (event) => { EnhancedAutoClicker.changeSelectedGym(event); });
+        document.getElementById('auto-dungeon-start').addEventListener('click', () => { EnhancedAutoClicker.toggleAutoDungeon(); });
+        document.getElementById('auto-dungeon-encounter-mode').addEventListener('click', () => { EnhancedAutoClicker.toggleAutoDungeonEncounterMode(); });
+        document.getElementById('auto-dungeon-chest-mode').addEventListener('click', () => { EnhancedAutoClicker.toggleAutoDungeonChestMode(); });
+        document.getElementById('checkbox-autoDungeonAlwaysOpenRareChests').addEventListener('change', () => { EnhancedAutoClicker.toggleAutoDungeonAlwaysOpenRareChests(); });
+        document.getElementById('checkbox-autoGymGraphicsDisabled').addEventListener('change', () => { EnhancedAutoClicker.toggleAutoGymGraphics(); });
+        document.getElementById('checkbox-autoDungeonGraphicsDisabled').addEventListener('change', () => { EnhancedAutoClicker.toggleAutoDungeonGraphics(); });
+        document.getElementById('select-autoClickCalcEfficiencyDisplayMode').addEventListener('change', (event) => { EnhancedAutoClicker.changeCalcEfficiencyDisplayMode(event); });
+        document.getElementById('select-autoClickCalcDamageDisplayMode').addEventListener('change', (event) => { EnhancedAutoClicker.changeCalcDamageDisplayMode(event); });
+
+        document.querySelectorAll('#auto-dungeon-loottier-dropdown > div').forEach((elem) => {
+            elem.addEventListener('click', () => { EnhancedAutoClicker.changeAutoDungeonLootTier(elem.getAttribute('value')); });
+        });
+
+        addGlobalStyle('#auto-click-info { display: flex; flex-direction: row; justify-content: center; }');
+        addGlobalStyle('#auto-click-info > div { width: 33.3%; }');
+        addGlobalStyle('#click-rate-cont { display: flex; flex-direction: column; align-items: stretch; }');
+        addGlobalStyle('#auto-dungeon-loottier-dropdown img { max-height: 30px; width: auto; }');
+
+        this.overrideGymRunner();
+        this.overrideDungeonRunner();
+
+        if (this.autoClickState()) {
+            this.toggleAutoClickerLoop();
+        }
+    }
+
+    /**
+     * Add extra Knockout data bindings to optionally disable (most) gym and dungeon graphics
+     */
+    static addGraphicsBindings() {
+        // Add gymView data bindings
+        var gymContainer = document.querySelector('div[data-bind="if: App.game.gameState === GameConstants.GameState.gym"]');
+        var elemsToBind = ['knockout[data-bind*="pokemonNameTemplate"]', // Pokemon name
+            'span[data-bind*="pokemonsDefeatedComputable"]', // Gym Pokemon counter (pt 1)
+            'span[data-bind*="pokemonsUndefeatedComputable"]', // Gym Pokemon counter (pt 2)
+            'knockout[data-bind*="pokemonSpriteTemplate"]', // Pokemon sprite
+            'div.progress.hitpoints', // Pokemon healthbar
+            'div.progress.timer' // Gym timer
+            ];
+        elemsToBind.forEach((query) => {
+            var elem = gymContainer.querySelector(query);
+            if (elem) {
+                elem.before(new Comment("ko ifnot: EnhancedAutoClicker.disableAutoGymGraphics()"));
+                elem.after(new Comment("/ko"));
+            }
+        });
+        // Always hide stop button during autoGym, even with graphics enabled
+        var restartButton = gymContainer.querySelector('button[data-bind="visible: GymRunner.autoRestart()"]');
+        restartButton.setAttribute('data-bind', 'visible: GymRunner.autoRestart() && !EnhancedAutoClicker.autoGymOn()');
+
+        // Add dungeonView data bindings
+        var dungeonContainer = document.querySelector('div[data-bind="if: App.game.gameState === GameConstants.GameState.dungeon"]');
+        // Title bar contents
+        dungeonContainer.querySelector('h2.pageItemTitle')?.prepend(new Comment("ko ifnot: EnhancedAutoClicker.disableAutoDungeonGraphics()"));
+        dungeonContainer.querySelector('h2.pageItemTitle')?.append(new Comment("/ko"));
+        // Main container sprites etc
+        dungeonContainer.querySelector('h2.pageItemTitle')?.after(new Comment("ko ifnot: EnhancedAutoClicker.disableAutoDungeonGraphics()"));
+        dungeonContainer.querySelector('h2.pageItemFooter')?.before(new Comment("/ko"));
+    }
+
+    /* Settings event handlers */
+
+    static toggleAutoClick() {
+        const element = document.getElementById('auto-click-start');
+        this.autoClickState(!this.autoClickState());
+        localStorage.setItem('autoClickState', this.autoClickState());
+        this.autoClickState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
+        this.toggleAutoClickerLoop();
+    }
+
+    static changeClickMultiplier(event) {
+        // TODO decide on a better range / function
+        const multiplier = +event.target.value;
+        if (Number.isInteger(multiplier) && multiplier > 0) {
+            this.autoClickMultiplier = multiplier;
+            localStorage.setItem("autoClickMultiplier", this.autoClickMultiplier);
+            var displayNum = (this.ticksPerSecond * this.autoClickMultiplier).toLocaleString('en-US', {maximumFractionDigits: 2});
+            document.getElementById('auto-click-rate-info').innerText = `Click Attack Rate: ${displayNum}/s`;
+            this.toggleAutoClickerLoop();
+        }
+    }
+
+    static toggleAutoGym() {
+        const element = document.getElementById('auto-gym-start');
+        this.autoGymState(!this.autoGymState());
+        localStorage.setItem('autoGymState', this.autoGymState());
+        this.autoGymState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
+        element.textContent = `Auto Gym [${this.autoGymState() ? 'ON' : 'OFF'}]`;
+        if (this.autoClickState() && !this.autoGymState()) {
+            // Only break out of this script's auto restart, not the built-in one
+            GymRunner.autoRestart(false);
+        }
+        if (this.autoGymState() && this.autoDungeonState()) {
+            // Only one mode may be active at a time
+            this.toggleAutoDungeon();
+        }
+    }
+
+    static changeSelectedGym(event) {
+        const val = +event.target.value;
+        if ([0, 1, 2, 3, 4].includes(val)) {
+            this.autoGymSelect = val;
+            localStorage.setItem("autoGymSelect", this.autoGymSelect);
+            // In case currently fighting a gym
+            if (this.autoClickState() && this.autoGymState()) {
+                // Only break out of this script's auto restart, not the built-in one
+                GymRunner.autoRestart(false);
+            }
+        }
+    }
+
+    static toggleAutoDungeon() {
+        const element = document.getElementById('auto-dungeon-start');
+        this.autoDungeonState(!this.autoDungeonState());
+        localStorage.setItem('autoDungeonState', this.autoDungeonState());
+        this.autoDungeonState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
+        element.textContent = `Auto Dungeon [${this.autoDungeonState() ? 'ON' : 'OFF'}]`;
+        if (this.autoDungeonState()) {
+            // Trigger a dungeon scan
+            this.autoDungeonTracker.ID = -1;
+        }
+        if (this.autoDungeonState() && this.autoGymState()) {
+            // Only one mode may be active at a time
+            this.toggleAutoGym();
+        }
+    }
+
+    static toggleAutoDungeonEncounterMode() {
+        this.autoDungeonEncounterMode = !this.autoDungeonEncounterMode;
+        $('#auto-dungeon-encounter-mode img').css('filter', `${this.autoDungeonEncounterMode ? '' : 'grayscale(100%)' }`);
+        localStorage.setItem('autoDungeonEncounterMode', this.autoDungeonEncounterMode);
+        this.autoDungeonTracker.coords = null;
+    }
+
+    static toggleAutoDungeonChestMode() {
+        this.autoDungeonChestMode = !this.autoDungeonChestMode;
+        $('#auto-dungeon-chest-mode img').css('filter', `${this.autoDungeonChestMode ? '' : 'grayscale(100%)' }`);
+        localStorage.setItem('autoDungeonChestMode', this.autoDungeonChestMode);
+        this.autoDungeonTracker.coords = null;
+    }
+
+    static changeAutoDungeonLootTier(tier) {
+        const val = +tier;
+        if ([-1, ...Object.keys(baseLootTierChance).keys()].includes(val)) {
+            this.autoDungeonLootTier = val;
+            if (val > -1) {
+                document.getElementById('auto-dungeon-loottier-img').setAttribute('src', `assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[val]}.png`);
+                document.getElementById('auto-dungeon-loottier-img').style.removeProperty('display');
+                document.getElementById('auto-dungeon-loottier-text').style.setProperty('display', 'none');
+            } else {
+                document.getElementById('auto-dungeon-loottier-img').setAttribute('src', '');
+                document.getElementById('auto-dungeon-loottier-img').style.setProperty('display', 'none');
+                document.getElementById('auto-dungeon-loottier-text').style.removeProperty('display');
+            }
+            localStorage.setItem("autoDungeonLootTier", this.autoDungeonLootTier);
+        }
+    }
+
+    static toggleAutoDungeonAlwaysOpenRareChests() {
+        this.autoDungeonAlwaysOpenRareChests = !this.autoDungeonAlwaysOpenRareChests;
+        localStorage.setItem('autoDungeonAlwaysOpenRareChests', this.autoDungeonAlwaysOpenRareChests);
+    }
+
+    static toggleAutoGymGraphics() {
+        this.gymGraphicsDisabled(!this.gymGraphicsDisabled());
+        localStorage.setItem('gymGraphicsDisabled', this.gymGraphicsDisabled());
+    }
+
+    static toggleAutoDungeonGraphics() {
+        this.dungeonGraphicsDisabled(!this.dungeonGraphicsDisabled());
+        localStorage.setItem('dungeonGraphicsDisabled', this.dungeonGraphicsDisabled());
+    }
+
+    static changeCalcEfficiencyDisplayMode(event) {
+        const val = +event.target.value;
+        if (val != this.autoClickCalcEfficiencyDisplayMode && [0, 1].includes(val)) {
+            this.autoClickCalcEfficiencyDisplayMode = val;
+            localStorage.setItem('autoClickCalcEfficiencyDisplayMode', this.autoClickCalcEfficiencyDisplayMode);
+            this.resetCalculator();
+        }
+    }
+
+    static changeCalcDamageDisplayMode(event) {
+        const val = +event.target.value;
+        if (val != this.autoClickCalcDamageDisplayMode && [0, 1].includes(val)) {
+            this.autoClickCalcDamageDisplayMode = val;
+            localStorage.setItem('autoClickCalcDamageDisplayMode', this.autoClickCalcDamageDisplayMode);
+            this.resetCalculator();
+        }
+    }
+
+    /* Auto Clicker */
+
+    /**
+     * Resets and, if enabled, restarts autoclicker
+     * -While enabled, runs <ticksPerSecond> times per second in active battle
+     */
+    static toggleAutoClickerLoop() {
+        var delay = Math.ceil(1000 / this.ticksPerSecond);
+        clearInterval(this.autoClickerLoop);
+        // Restart stats calculator
+        this.resetCalculator();
+        // Only use click multiplier while autoclicking
+        this.overrideClickAttack(this.autoClickState() ? this.autoClickMultiplier : 1);
+        if (this.autoClickState()) {
+            // Start autoclicker loop
+            this.autoClickerLoop = setInterval(() => EnhancedAutoClicker.autoClicker(), delay);
+        } else {
+            if (this.autoGymState()) {
+                GymRunner.autoRestart(false);
+            }
+        }
+    }
+
+    /**
+     * One tick of the autoclicker
+     * -Performs click attacks while in an active battle
+     * -Outside of battle, runs Auto Dungeon and Auto Gym
+     */
+    static autoClicker() {
+        // Click while in a normal battle
+        if (App.game.gameState === GameConstants.GameState.fighting) {
+            Battle.clickAttack(this.autoClickMultiplier);
+        }
+        // ...or gym battle
+        else if (App.game.gameState === GameConstants.GameState.gym) {
+            GymBattle.clickAttack(this.autoClickMultiplier);
+        }
+        // ...or dungeon battle
+        else if (App.game.gameState === GameConstants.GameState.dungeon && DungeonRunner.fighting()) {
+            DungeonBattle.clickAttack(this.autoClickMultiplier);
+        }
+        // ...or temporary battle
+        else if (App.game.gameState === GameConstants.GameState.temporaryBattle) {
+            TemporaryBattleBattle.clickAttack(this.autoClickMultiplier);
+        }
+        // If not battling, progress through dungeon
+        else if (this.autoDungeonState()) {
+            this.autoDungeon();
+        }
+        // If not battling gym, start battling
+        else if (this.autoGymState()) {
+            this.autoGym();
+        }
+        this.autoClickCalcTracker.ticks[0]++;
+    }
+
+    /**
+     * Override the game's function for Click Attack to:
+     * - make multiple clicks at once via multiplier
+     * - support changing the attack speed cap for higher tick speeds
+     */
+    static overrideClickAttack(clickMultiplier = 1) {
+        // Set delay based on the autoclicker's tick rate
+        // (lower to give setInterval some wiggle room)
+        const delay = Math.min(Math.ceil(1000 / this.ticksPerSecond) - 10, 50);
+        Battle.clickAttackCached = 0;
+        Battle.clickAttackLastCached = 0;
+        Battle.clickAttack = function () {
+            // click attacks disabled and we already beat the starter
+            if (App.game.challenges.list.disableClickAttack.active() && player.regionStarters[GameConstants.Region.kanto]() != GameConstants.Starter.None) {
+                return;
+            }
+            const now = Date.now();
+            if (now - this.lastClickAttack < delay) {
+                return;
+            }
+            if (!this.enemyPokemon()?.isAlive()) {
+                return;
+            }
+            this.lastClickAttack = now;
+            // Avoid recalculating damage 20 times per second
+            if (now - this.clickAttackLastCached > 1000) {
+                this.clickAttackCached = App.game.party.calculateClickAttack(true);
+                this.clickAttackLastCached = now;
+            }
+            // Don't autoclick more than needed for lethal
+            var clicks = Math.min(clickMultiplier, Math.ceil(this.enemyPokemon().health() / this.clickAttackCached));
+            GameHelper.incrementObservable(App.game.statistics.clickAttacks, clicks);
+            this.enemyPokemon().damage(this.clickAttackCached * clicks);
+            if (!this.enemyPokemon().isAlive()) {
+                this.defeatPokemon();
+            }
+        }
+    }
+
+
+    /* Auto Gym */
+
+    /**
+     * Starts selected gym with auto restart enabled
+     */
+    static autoGym() {
+        if (App.game.gameState === GameConstants.GameState.town) {
+            // Find all unlocked gyms in the current town
+            var gymList = player.town().content.filter((c) => (c.constructor.name == "Gym" && c.isUnlocked()));
+            if (gymList.length > 0) {
+                var gymIndex = Math.min(this.autoGymSelect, gymList.length - 1);
+                // Start in auto restart mode
+                GymRunner.startGym(gymList[gymIndex], true);
+                return;
+            }
+        }
+        // Disable if we aren't in a location with unlocked gyms
+        this.toggleAutoGym();
+    }
+
+    /**
+     * Override GymRunner built-in functions:
+     * -Add auto gym equivalent of gymWon() to save on performance by not loading town between
+     */
+    static overrideGymRunner() {
+        GymRunner.gymWonNormal = GymRunner.gymWon;
+        // Version with free auto restart
+        GymRunner.gymWonAuto = function(gym) {
+            if (GymRunner.running()) {
+                GymRunner.running(false);
+                // First time defeating this gym
+                if (!App.game.badgeCase.hasBadge(gym.badgeReward)) {
+                    gym.firstWinReward();
+                }
+                GameHelper.incrementObservable(App.game.statistics.gymsDefeated[GameConstants.getGymIndex(gym.town)]);
+                // Award money for defeating gym as we're auto clicking
+                App.game.wallet.gainMoney(gym.moneyReward);
+
+                if (GymRunner.autoRestart()) {
+                    // Unlike the original function, autoclicker doesn't charge the player money
+                    GymRunner.startGym(GymRunner.gymObservable(), GymRunner.autoRestart(), false);
+                    return;
+                }
+
+                // Send the player back to the town they were in
+                player.town(gym.parent);
+                App.game.gameState = GameConstants.GameState.town;
+            }
+        }
+        // Only use our version when auto gym is running
+        GymRunner.gymWon = function(...args) {
+            if (EnhancedAutoClicker.autoClickState() && EnhancedAutoClicker.autoGymState()) {
+                GymRunner.gymWonAuto(...args);
+            } else {
+                GymRunner.gymWonNormal(...args);
+            }
+        }
+    }
+
+    /* Auto Dungeon */
+
+    /**
+     * Automatically begins and progresses through dungeons with multiple pathfinding options
+     */
+    static autoDungeon() { // TODO more thoroughly test switching between modes and enabling/disabling within a dungeon
+        // Progress through dungeon
+        if (App.game.gameState === GameConstants.GameState.dungeon) {
+            if (DungeonRunner.fighting() || DungeonBattle.catching()) {
+                return;
+            }
+            // Scan each new dungeon floor
+            if (this.autoDungeonTracker.ID !== DungeonRunner.dungeonID || this.autoDungeonTracker.floor !== DungeonRunner.map.playerPosition().floor) {
+                this.scanDungeon();
+            }
+            // Reset pathfinding coordinates to entrance
+            if (this.autoDungeonTracker.coords == null) {
+                this.autoDungeonTracker.coords = new Point(Math.floor(this.autoDungeonTracker.floorSize / 2), this.autoDungeonTracker.floorSize - 1, this.autoDungeonTracker.floor);
+            }
+            const floorMap = DungeonRunner.map.board()[this.autoDungeonTracker.floor];
+
+            // All targets visible, fight enemies / open chests then finish floor
+            if (floorMap[this.autoDungeonTracker.bossCoords.y][this.autoDungeonTracker.bossCoords.x].isVisible &&
+                !((this.autoDungeonChestMode || this.autoDungeonEncounterMode) && !this.autoDungeonTracker.floorExplored)) {
+                this.clearDungeon();
+            }
+            // Explore dungeon to reveal boss + any target tiles
+            else {
+                this.exploreDungeon();
+            }
+        }
+        // Begin dungeon
+        else {
+            if (App.game.gameState === GameConstants.GameState.town && player.town() instanceof DungeonTown) {
+                const dungeon = player.town().dungeon;
+                // Enter dungeon if unlocked and affordable
+                if (dungeon?.isUnlocked() && App.game.wallet.hasAmount(new Amount(dungeon.tokenCost, GameConstants.Currency.dungeonToken))) {
+                    DungeonRunner.initializeDungeon(dungeon);
+                    return;
+                }
+            }
+            // Disable if locked, can't afford entry cost, or there's no dungeon here
+            this.toggleAutoDungeon();
+        }
+    }
+
+    /**
+     * Scans current dungeon floor for relevant locations and pathfinding data
+     */
+    static scanDungeon() {
+        // Reset / update tracker values
+        this.autoDungeonTracker.ID = DungeonRunner.dungeonID;
+        this.autoDungeonTracker.floor = DungeonRunner.map.playerPosition().floor;
+        this.autoDungeonTracker.floorSize = DungeonRunner.map.floorSizes[DungeonRunner.map.playerPosition().floor];
+        this.autoDungeonTracker.encounterCoords = [];
+        this.autoDungeonTracker.chestCoords = [];
+        this.autoDungeonTracker.coords = null;
+        this.autoDungeonTracker.targetCoords = null;
+        this.autoDungeonTracker.floorExplored = false;
+        this.autoDungeonTracker.floorFinished = false;
+
+        // Scan for chest and boss coordinates
+        var dungeonBoard = DungeonRunner.map.board()[this.autoDungeonTracker.floor];
+        for (var y = 0; y < dungeonBoard.length; y++) {
+            for (var x = 0; x < dungeonBoard[y].length; x++) {
+                let tile = dungeonBoard[y][x];
+                if (tile.type() == GameConstants.DungeonTile.enemy) {
+                    this.autoDungeonTracker.encounterCoords.push(new Point(x, y, this.autoDungeonTracker.floor));
+                } else if (tile.type() == GameConstants.DungeonTile.chest) {
+                    let lootTier = Object.keys(baseLootTierChance).indexOf(tile.metadata.tier);
+                    this.autoDungeonTracker.chestCoords.push({'xy': new Point(x, y, this.autoDungeonTracker.floor), 'tier': lootTier});
+                } else if (tile.type() == GameConstants.DungeonTile.boss || tile.type() == GameConstants.DungeonTile.ladder) {
+                    this.autoDungeonTracker.bossCoords = new Point(x, y, this.autoDungeonTracker.floor);
+                }
+            }
+        }
+        // Sort chests by descending rarity
+        this.autoDungeonTracker.chestCoords.sort((a, b) => b.tier - a.tier);
+
+        // TODO find a more future-proof way to get flash distance
+        this.autoDungeonTracker.flashTier = DungeonFlash.tiers.findIndex(tier => tier === DungeonRunner.map.flash);
+        this.autoDungeonTracker.flashCols = [];
+        let flashRadius = DungeonRunner.map.flash?.playerOffset[0] ?? 0;
+        // Calculate minimum columns to fully reveal dungeon with Flash
+        if (flashRadius > 0) {
+            let cols = new Set();
+            cols.add(flashRadius);
+            let i = this.autoDungeonTracker.floorSize - flashRadius - 1;
+            while (i > flashRadius) {
+                cols.add(i);
+                i -= flashRadius * 2 + 1;
+            }
+            this.autoDungeonTracker.flashCols = [...cols].sort();
+        }
+    }
+
+    /**
+     * Explores dungeon to reveal tiles, skipping columns that can be efficiently revealed by Flash
+     */
+    static exploreDungeon() {
+        const dungeonBoard = DungeonRunner.map.board()[this.autoDungeonTracker.floor];
+        var hasMoved = false;
+        while (!hasMoved) {
+            // End of column, move to start of new column
+            if (this.autoDungeonTracker.coords.y == 0) {
+                this.autoDungeonTracker.coords.y = this.autoDungeonTracker.floorSize - 1;
+                if (this.autoDungeonTracker.coords.x >= this.autoDungeonTracker.floorSize - 1 || this.autoDungeonTracker.coords.x === this.autoDungeonTracker.flashCols.at(-1)) {
+                    // Done with this side, move to other side of the entrance
+                    this.autoDungeonTracker.coords.x = Math.floor(this.autoDungeonTracker.floorSize / 2) - 1;
+                } else if (this.autoDungeonTracker.coords.x == 0 || this.autoDungeonTracker.coords.x === this.autoDungeonTracker.flashCols[0]) {
+                    // Done exploring, clearDungeon() will take over from here
+                    this.autoDungeonTracker.floorExplored = true;
+                    return;
+                } else {
+                    // Move away from the entrance
+                    this.autoDungeonTracker.coords.x += (this.autoDungeonTracker.coords.x >= Math.floor(this.autoDungeonTracker.floorSize / 2) ? 1 : -1);
+                }
+            // Dungeon has Flash unlocked, skip columns not in optimal flash pathing
+            } else if (this.autoDungeonTracker.flashTier > -1
+                && this.autoDungeonTracker.coords.y == (this.autoDungeonTracker.floorSize - 1)
+                && !this.autoDungeonTracker.flashCols.includes(this.autoDungeonTracker.coords.x)) {
+                // Move one column further from the entrance
+                this.autoDungeonTracker.coords.x += (this.autoDungeonTracker.coords.x >= Math.floor(this.autoDungeonTracker.floorSize / 2) ? 1 : -1);
+            }
+            // Move through current column
+            else {
+                this.autoDungeonTracker.coords.y -= 1;
+            }
+            // One move per tick to look more natural
+            if (!dungeonBoard[this.autoDungeonTracker.coords.y][this.autoDungeonTracker.coords.x].isVisited) {
+                DungeonRunner.map.moveToCoordinates(this.autoDungeonTracker.coords.x, this.autoDungeonTracker.coords.y);
+                hasMoved = true;
+            }
+        }
+    }
+
+    /**
+     * Clears dungeon, visiting all desired tile types. Assumes dungeon has already been explored to reveal desired tiles.
+     */
+    static clearDungeon() {
+        const dungeonBoard = DungeonRunner.map.board()[this.autoDungeonTracker.floor];
+        var hasMoved = false;
+        var stuckInLoopCounter = 0;
+        while (!hasMoved) {
+            // Choose a tile to move towards
+            if (!this.autoDungeonTracker.targetCoords) {
+                this.autoDungeonTracker.targetCoords = this.chooseDungeonTargetTile();
+            }
+            this.autoDungeonTracker.coords = this.pathfindTowardDungeonTarget();
+            if (!this.autoDungeonTracker.coords) {
+                console.warn(`Auto Dungeon could not find path to target tile \'${GameConstants.DungeonTile[dungeonBoard[this.autoDungeonTracker.targetCoords.y][this.autoDungeonTracker.targetCoords.x].type()]}\' (${this.autoDungeonTracker.targetCoords.x}, ${this.autoDungeonTracker.targetCoords.y})`);
+                this.toggleAutoDungeon();
+                return;
+            }
+            // One move per tick to look more natural
+            if (!(dungeonBoard[this.autoDungeonTracker.coords.y][this.autoDungeonTracker.coords.x] === DungeonRunner.map.currentTile())) {
+                DungeonRunner.map.moveToCoordinates(this.autoDungeonTracker.coords.x, this.autoDungeonTracker.coords.y);
+                hasMoved = true;
+            }
+            // Target tile reached
+            if (this.autoDungeonTracker.coords.x === this.autoDungeonTracker.targetCoords.x && this.autoDungeonTracker.coords.y === this.autoDungeonTracker.targetCoords.y) {
+                this.autoDungeonTracker.targetCoords = null;
+                hasMoved = true;
+                // Take corresponding action
+                const tileType = DungeonRunner.map.currentTile().type();
+                if (tileType === GameConstants.DungeonTile.enemy) {
+                    // Do nothing, fights begin automatically
+                } else if (tileType === GameConstants.DungeonTile.chest) {
+                    DungeonRunner.openChest();
+                } else if (tileType === GameConstants.DungeonTile.boss) {
+                    if (this.autoDungeonTracker.floorFinished) {
+                        DungeonRunner.startBossFight();
+                    }
+                } else if (tileType === GameConstants.DungeonTile.ladder) {
+                    if (this.autoDungeonTracker.floorFinished) {
+                        DungeonRunner.nextFloor();
+                    }
+                } else {
+                    console.warn(`Auto Dungeon targeted tile type ${GameConstants.DungeonTile[tileType]}`);
+                }
+            }
+            stuckInLoopCounter++;
+            if (stuckInLoopCounter > 5) {
+                console.warn(`Auto Dungeon got stuck in a loop while moving to tile \'${GameConstants.DungeonTile[dungeonBoard[this.autoDungeonTracker.targetCoords.y][this.autoDungeonTracker.targetCoords.x].type()]}\' (${this.autoDungeonTracker.targetCoords.x}, ${this.autoDungeonTracker.targetCoords.y})`);
+                this.toggleAutoDungeon();
+                return;
+            }
+        }
+    }
+
+    static chooseDungeonTargetTile() {
+        const dungeonBoard = DungeonRunner.map.board()[this.autoDungeonTracker.floor];
+        let target = null;
+        while (!target) {
+            // Boss tile not yet unlocked
+            if (!dungeonBoard[this.autoDungeonTracker.bossCoords.y][this.autoDungeonTracker.bossCoords.x].isVisited) {
+                target = this.autoDungeonTracker.bossCoords;
+            }
+            // Encounters to fight
+            else if (this.autoDungeonEncounterMode && this.autoDungeonTracker.encounterCoords.length) {
+                // Skip already-fought encounters
+                let encounter = this.autoDungeonTracker.encounterCoords.pop();
+                if (dungeonBoard[encounter.y][encounter.x].type() == GameConstants.DungeonTile.enemy) {
+                    target = encounter;
+                } else {
+                    continue;
+                }
+            }
+            // Chests to open
+            else if (this.autoDungeonChestMode && this.autoDungeonTracker.chestCoords.length && this.autoDungeonTracker.chestCoords[0].tier >= this.autoDungeonLootTier) {
+                target = this.autoDungeonTracker.chestCoords.shift().xy;
+            }
+            // Open visible chests of sufficient rarity
+            else if (this.autoDungeonAlwaysOpenRareChests && this.autoDungeonTracker.chestCoords.some((c) => c.tier >= this.autoDungeonLootTier && dungeonBoard[c.xy.y][c.xy.x].isVisible)) {
+                let index = this.autoDungeonTracker.chestCoords.findIndex((c) => c.tier >= this.autoDungeonLootTier && dungeonBoard[c.xy.y][c.xy.x].isVisible);
+                target = this.autoDungeonTracker.chestCoords[index].xy;
+                this.autoDungeonTracker.chestCoords.splice(index, 1);
+            }
+            // Time to fight the boss
+            else {
+                target = this.autoDungeonTracker.bossCoords;
+                this.autoDungeonTracker.floorFinished = true;
+            }
+        }
+        return target;
+    }
+
+    /** 
+     * Find next tile on the shortest path towards target via breadth-first search
+     */
+    static pathfindTowardDungeonTarget() {
+        const target = this.autoDungeonTracker.targetCoords;
+        let result = null;
+        if (!target) {
+            return result;
+        }
+        const queue = [target];
+        const visited = new Set(`${target.x}-${target.y}`);
+        while (queue.length) {
+            const p = queue.shift();
+            if (DungeonRunner.map.hasAccessToTile(p)) {
+                result = p;
+                break;
+            }
+            const adjTiles = [[p.x - 1, p.y], [p.x + 1, p.y], [p.x, p.y - 1], [p.x, p.y + 1]];
+            for (let [nx, ny] of adjTiles) {
+                // Enqueue valid tiles not yet considered
+                let xy = `${nx}-${ny}`;
+                if (0 <= nx && nx < this.autoDungeonTracker.floorSize && 0 <= ny && ny < this.autoDungeonTracker.floorSize && !visited.has(xy)) {
+                    queue.push(new Point(nx, ny, target.floor));
+                    visited.add(xy);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Override DungeonRunner built-in functions*:
+     * -Add dungeon ID tracking to initializeDungeon() for easier mapping
+     * -Add auto dungeon equivalent of dungeonWon() to save on performance by restarting without loading town
+     */
+    static overrideDungeonRunner() {
+        // Differentiate between dungeons for mapping
+        DungeonRunner.dungeonID = 0;
+        const oldInit = DungeonRunner.initializeDungeon.bind(DungeonRunner);
+        DungeonRunner.initializeDungeon = function (...args) {
+            DungeonRunner.dungeonID++;
+            return oldInit(...args);
+        }
+
+        DungeonRunner.dungeonWonNormal = DungeonRunner.dungeonWon;
+        // Version with integrated auto-restart to avoid loading town in between dungeons
+        DungeonRunner.dungeonWonAuto = function () {
+            if (!DungeonRunner.dungeonFinished()) {
+                DungeonRunner.dungeonFinished(true);
+                // First time clearing dungeon
+                if (!App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]()) {
+                    DungeonRunner.dungeon.rewardFunction();
+                }
+                GameHelper.incrementObservable(App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]);
+
+                // Auto restart dungeon
+                if (DungeonRunner.hasEnoughTokens()) {
+                    // Clear old board to force map visuals refresh
+                    DungeonRunner.map.board([]);
+                    DungeonRunner.initializeDungeon(DungeonRunner.dungeon);
+                    return;
+                }
+
+                MapHelper.moveToTown(DungeonRunner.dungeon.name);
+            }
+        }
+        // Only use our version when auto dungeon is running
+        DungeonRunner.dungeonWon = function (...args) {
+            if (EnhancedAutoClicker.autoClickState() && EnhancedAutoClicker.autoDungeonState()) {
+                DungeonRunner.dungeonWonAuto(...args);
+            } else {
+                DungeonRunner.dungeonWonNormal(...args);
+            }
+        }
+    }
+
+    /* Clicker statistics calculator */
+
+    /**
+     * Resets calculator loop, stats trackers, and calculator display
+     * -If auto clicker is running, restarts calculator
+     */
+    static resetCalculator() {
+        clearInterval(this.autoClickCalcLoop);
+        this.autoClickCalcTracker.lastUpdate = [Date.now()];
+        this.autoClickCalcTracker.ticks = [0];
+        this.autoClickCalcTracker.clicks = [App.game.statistics.clickAttacks()];
+        this.autoClickCalcTracker.enemies = [App.game.statistics.totalPokemonDefeated()];
+        this.calculateAreaHealth();
+        document.getElementById('auto-click-info').innerHTML = `<div>${this.autoClickCalcEfficiencyDisplayMode == 0 ? 'Clicker Efficiency' : 'Ticks/s'}:<br><div id="tick-efficiency" style="font-weight:bold;">-</div></div>
+            <div>${this.autoClickCalcDamageDisplayMode == 0 ? 'Click Attacks/s' : 'DPS'}:<br><div id="clicks-per-second" style="font-weight:bold;">-</div></div>
+            <div>Req. ${this.autoClickCalcDamageDisplayMode == 0 ? 'Clicks' : 'Click Damage'}:<br><div id="req-clicks" style="font-weight:bold;">-</div></div>
+            <div>Enemies/s:<br><div id="enemies-per-second" style="font-weight:bold;">-</div></div>`;
+        if (this.autoClickState()) {
+            // Start calculator
+            this.autoClickCalcLoop = setInterval(() => EnhancedAutoClicker.calcClickStats(), 1000);
+        }
+    }
+
+    /**
+     * Displays the following statistics, averaged over the last (up to) ten seconds:
+     * -Percentage of ticksPerSecond the autoclicker is actually executing
+     * -Clicks per second or damage per second, depending on display mode
+     * -Required number of clicks or click attack damage to one-shot the current location, depending on display mode
+     * --Ignores dungeon bosses and chest health increases
+     * -Enemies defeated per second
+     * Statistics are reset when the player changes locations
+     */
+    static calcClickStats() {
+        if (this.hasPlayerMoved()) {        
+            // Reset statistics on area / game state change
+            this.resetCalculator();
+            return;
+        }
+        var elem;
+        var clickDamage = App.game.party.calculateClickAttack(true);
+        var actualElapsed = (Date.now() - this.autoClickCalcTracker.lastUpdate.at(-1)) / (1000 * this.autoClickCalcTracker.lastUpdate.length);
+
+        // Percentage of maximum ticksPerSecond
+        elem = document.getElementById('tick-efficiency');
+        var avgTicks = this.autoClickCalcTracker.ticks.reduce((a, b) => a + b, 0) / this.autoClickCalcTracker.ticks.length;
+        avgTicks = avgTicks / actualElapsed;
+        if (this.autoClickCalcEfficiencyDisplayMode == 1) {
+            // display ticks mode
+            elem.innerHTML = avgTicks.toLocaleString('en-US', {maximumFractionDigits: 1} );
+            elem.style.color = 'gold';
+        } else {
+            // display percentage mode
+            var tickFraction = avgTicks / this.ticksPerSecond;
+            elem.innerHTML = tickFraction.toLocaleString('en-US', {style: 'percent', maximumFractionDigits: 0} );
+            elem.style.color = 'gold';
+        }
+
+        // Average clicks/damage per second
+        elem = document.getElementById('clicks-per-second');
+        var avgClicks = (App.game.statistics.clickAttacks() - this.autoClickCalcTracker.clicks.at(-1)) / this.autoClickCalcTracker.clicks.length;
+        avgClicks = avgClicks / actualElapsed;
+        if (this.autoClickCalcDamageDisplayMode == 1) {
+            // display damage mode
+            var avgDPS = avgClicks * clickDamage;
+            elem.innerHTML = avgDPS.toLocaleString('en-US', {maximumFractionDigits: 0});
+            elem.style.color = 'gold';
+        } else {
+            // display click attacks mode
+            elem.innerHTML = avgClicks.toLocaleString('en-US', {maximumFractionDigits: 1});
+            elem.style.color = 'gold';
+        }
+
+        // Required clicks/click damage
+        elem = document.getElementById('req-clicks');
+        if (this.autoClickCalcTracker.areaHealth == 0) {
+            // can't meaningfully calculate a value for this area/game state
+            elem.innerHTML = '-';
+            elem.style.removeProperty('color');
+        } else if (this.autoClickCalcDamageDisplayMode == 1) {
+            // display damage mode
+            var reqDamage = this.autoClickCalcTracker.areaHealth;
+            elem.innerHTML = reqDamage.toLocaleString('en-US');
+            elem.style.color = (clickDamage * this.autoClickMultiplier >= reqDamage ? 'greenyellow' : 'darkred');
+        } else {
+            // display clicks mode
+            var reqClicks = Math.max((this.autoClickCalcTracker.areaHealth / clickDamage), 1);
+            reqClicks = Math.ceil(reqClicks * 10) / 10; // round up to one decimal point
+            elem.innerHTML = reqClicks.toLocaleString('en-US', {maximumFractionDigits: 1});
+            elem.style.color = (reqClicks <= this.autoClickMultiplier ? 'greenyellow' : 'darkred');
+        }
+
+        // Enemies per second
+        elem = document.getElementById('enemies-per-second');
+        var avgEnemies = (App.game.statistics.totalPokemonDefeated() - this.autoClickCalcTracker.enemies.at(-1)) / this.autoClickCalcTracker.enemies.length;
+        avgEnemies = avgEnemies / actualElapsed;
+        elem.innerHTML = avgEnemies.toLocaleString('en-US', {maximumFractionDigits: 1});
+        elem.style.color = 'gold';
+
+        // Make room for next second's stats tracking
+        // Add new entries to start of array for easier incrementing
+        this.autoClickCalcTracker.ticks.unshift(0);
+        if (this.autoClickCalcTracker.ticks.length > 10) {
+            this.autoClickCalcTracker.ticks.pop();
+        }
+        this.autoClickCalcTracker.clicks.unshift(App.game.statistics.clickAttacks());
+        if (this.autoClickCalcTracker.clicks.length > 10) {
+            this.autoClickCalcTracker.clicks.pop();
+        }
+        this.autoClickCalcTracker.enemies.unshift(App.game.statistics.totalPokemonDefeated());
+        if (this.autoClickCalcTracker.enemies.length > 10) {
+            this.autoClickCalcTracker.enemies.pop();
+        }
+        this.autoClickCalcTracker.lastUpdate.unshift(Date.now());
+        if (this.autoClickCalcTracker.lastUpdate.length > 10) {
+            this.autoClickCalcTracker.lastUpdate.pop();
+        }
+    }
+
+    /**
+     * Check whether player state or location has changed
+     */
+    static hasPlayerMoved() {
+        var moved = false;
+        let newState = App.game.gameState;
+        // Special case: between dungeon instances while Auto Dungeon is running 
+        if (this.autoDungeonState() && App.game.gameState === GameConstants.GameState.town && player.town() instanceof DungeonTown) {
+            newState = GameConstants.GameState.dungeon;
+        }
+        if (this.autoClickCalcTracker.playerState != newState) {
+            this.autoClickCalcTracker.playerState = newState;
+            moved = true;
+        }
+        let newLocation;
+        if (App.game.gameState === GameConstants.GameState.gym) {
+            newLocation = GymRunner.gymObservable().leaderName;
+        } else if (App.game.gameState === GameConstants.GameState.dungeon) {
+            newLocation = DungeonRunner.dungeon.name;
+        } else if (App.game.gameState === GameConstants.GameState.temporaryBattle) {
+            newLocation = TemporaryBattleRunner.battleObservable().name;
+        } else {
+            // Conveniently, player.route() = 0 when not on a route
+            newLocation = player.route() || player.town().name;
+        }
+        if (this.autoClickCalcTracker.playerLocation != newLocation) {
+            this.autoClickCalcTracker.playerLocation = newLocation;
+            moved = true;
+        }
+        
+        return moved;
+    }
+
+    /**
+     * Calculate max Pokemon health for the current route/gym/dungeon
+     * -Ignores dungeon boss HP and chest HP increases
+     */
+    static calculateAreaHealth() {
+        // Calculate area max hp
+        if (App.game.gameState === GameConstants.GameState.fighting) {
+            this.autoClickCalcTracker.areaHealth = PokemonFactory.routeHealth(player.route(), player.region);
+            // Adjust for route health variation (adapted from PokemonFactory.generateWildPokemon)
+            const pokeHP = [...new Set(Object.values(Routes.getRoute(player.region, player.route()).pokemon).flat().flatMap(p => p.pokemon ?? p))].map(p => pokemonMap[p].base.hitpoints);
+            const averageHP = pokeHP.reduce((s, a) => s + a, 0) / pokeHP.length;
+            const highestHP = pokeHP.reduce((m, a) => Math.max(m, a), 0);
+            this.autoClickCalcTracker.areaHealth = Math.round(this.autoClickCalcTracker.areaHealth * (0.9 + (highestHP / averageHP) / 10));
+        } else if (App.game.gameState === GameConstants.GameState.gym) {
+            // Get highest health gym pokemon
+            this.autoClickCalcTracker.areaHealth = GymRunner.gymObservable().getPokemonList().reduce((a, b) => Math.max(a, b.maxHealth), 0);
+        } else if (App.game.gameState === GameConstants.GameState.dungeon) {
+            this.autoClickCalcTracker.areaHealth = DungeonRunner.dungeon.baseHealth;
+        } else if (App.game.gameState === GameConstants.GameState.temporaryBattle) {
+            // Get highest health trainer pokemon
+            this.autoClickCalcTracker.areaHealth = TemporaryBattleRunner.battleObservable().getPokemonList().reduce((a, b) => Math.max(a, b.maxHealth), 0);
+        } else {
+            this.autoClickCalcTracker.areaHealth = 0;
+        }
+    }
+}
+
+/**
+ * Loads variable from localStorage
+ * -Returns value from localStorage if it exists and is correct type
+ * -Otherwise returns null
+ */
+function validateStorage(key, defaultVal, allowed) {
+    try {
+        var val = localStorage.getItem(key);
+        val = JSON.parse(val);
+        if (val == null || typeof val !== typeof defaultVal || (typeof val == 'object' && val.constructor.name !== defaultVal.constructor.name)) {
+            return defaultVal;
+        }
+        if (allowed != undefined) {
+            if (Array.isArray(allowed) && !allowed.includes(val)) {
+                return defaultVal;
+            }
+            if (allowed instanceof Function && !allowed(val)) {
+                return defaultVal;
+            }
+        }
+        return val;
+    } catch {
+        return defaultVal;
     }
 }
 
@@ -260,876 +1084,6 @@ function addGlobalStyle(css) {
     head.appendChild(style);
 }
 
-/* Settings event handlers */
-
-function toggleAutoClick() {
-    const element = document.getElementById('auto-click-start');
-    autoClickState(!autoClickState());
-    localStorage.setItem('autoClickState', autoClickState());
-    autoClickState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
-    autoClicker();
-}
-
-function changeClickMultiplier(event) {
-    // TODO decide on a better range / function
-    const multiplier = +event.target.value;
-    if (Number.isInteger(multiplier) && multiplier > 0) {
-        autoClickMultiplier = multiplier;
-        localStorage.setItem("autoClickMultiplier", autoClickMultiplier);
-        var displayNum = (ticksPerSecond * autoClickMultiplier).toLocaleString('en-US', {maximumFractionDigits: 2});
-        document.getElementById('auto-click-rate-info').innerText = `Click Attack Rate: ${displayNum}/s`;
-        autoClicker();
-    }
-}
-
-function toggleAutoGym() {
-    const element = document.getElementById('auto-gym-start');
-    autoGymState(!autoGymState());
-    localStorage.setItem('autoGymState', autoGymState());
-    autoGymState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
-    element.textContent = `Auto Gym [${autoGymState() ? 'ON' : 'OFF'}]`;
-    if (autoClickState() && !autoGymState()) {
-        // Only break out of this script's auto restart, not the built-in one
-        GymRunner.autoRestart(false);
-    }
-}
-
-function changeSelectedGym(event) {
-    const val = +event.target.value;
-    if ([0, 1, 2, 3, 4].includes(val)) {
-        autoGymSelect = val;
-        localStorage.setItem("autoGymSelect", autoGymSelect);
-        // In case currently fighting a gym
-        if (autoClickState() && autoGymState()) {
-            // Only break out of this script's auto restart, not the built-in one
-            GymRunner.autoRestart(false);
-        }
-    }
-}
-
-function toggleAutoDungeon() {
-    const element = document.getElementById('auto-dungeon-start');
-    autoDungeonState(!autoDungeonState());
-    localStorage.setItem('autoDungeonState', autoDungeonState());
-    autoDungeonState() ? element.classList.replace('btn-danger', 'btn-success') : element.classList.replace('btn-success', 'btn-danger');
-    element.textContent = `Auto Dungeon [${autoDungeonState() ? 'ON' : 'OFF'}]`;
-    if (autoDungeonState()) {
-        // Trigger a dungeon scan
-        autoDungeonTracker.ID = -1;
-    }
-}
-
-function toggleAutoDungeonEncounterMode() {
-    autoDungeonEncounterMode = !autoDungeonEncounterMode;
-    $('#auto-dungeon-encounter-mode img').css('filter', `${autoDungeonEncounterMode ? '' : 'grayscale(100%)' }`);
-    localStorage.setItem('autoDungeonEncounterMode', autoDungeonEncounterMode);
-    autoDungeonTracker.coords = null;
-}
-
-function toggleAutoDungeonChestMode() {
-    autoDungeonChestMode = !autoDungeonChestMode;
-    $('#auto-dungeon-chest-mode img').css('filter', `${autoDungeonChestMode ? '' : 'grayscale(100%)' }`);
-    localStorage.setItem('autoDungeonChestMode', autoDungeonChestMode);
-    autoDungeonTracker.coords = null;
-}
-
-function changeAutoDungeonLootTier(tier) {
-    const val = +tier;
-    if ([-1, ...Object.keys(baseLootTierChance).keys()].includes(val)) {
-        autoDungeonLootTier = val;
-        if (val > -1) {
-            document.getElementById('auto-dungeon-loottier-img').setAttribute('src', `assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[val]}.png`);
-            document.getElementById('auto-dungeon-loottier-img').style.removeProperty('display');
-            document.getElementById('auto-dungeon-loottier-text').style.setProperty('display', 'none');
-        } else {
-            document.getElementById('auto-dungeon-loottier-img').setAttribute('src', '');
-            document.getElementById('auto-dungeon-loottier-img').style.setProperty('display', 'none');
-            document.getElementById('auto-dungeon-loottier-text').style.removeProperty('display');
-        }
-        localStorage.setItem("autoDungeonLootTier", autoDungeonLootTier);
-    }
-}
-
-function toggleAutoDungeonAlwaysOpenRareChests() {
-    autoDungeonAlwaysOpenRareChests = !autoDungeonAlwaysOpenRareChests;
-    localStorage.setItem('autoDungeonAlwaysOpenRareChests', autoDungeonAlwaysOpenRareChests);
-}
-
-function toggleAutoGymGraphics() {
-    gymGraphicsDisabled(!gymGraphicsDisabled());
-    localStorage.setItem('gymGraphicsDisabled', gymGraphicsDisabled());
-}
-
-function toggleAutoDungeonGraphics() {
-    dungeonGraphicsDisabled(!dungeonGraphicsDisabled());
-    localStorage.setItem('dungeonGraphicsDisabled', dungeonGraphicsDisabled());
-}
-
-function changeCalcEfficiencyDisplayMode(event) {
-    const val = +event.target.value;
-    if (val != autoClickCalcEfficiencyDisplayMode && [0, 1].includes(val)) {
-        autoClickCalcEfficiencyDisplayMode = val;
-        localStorage.setItem('autoClickCalcEfficiencyDisplayMode', autoClickCalcEfficiencyDisplayMode);
-        resetCalculator();
-    }
-}
-
-function changeCalcDamageDisplayMode(event) {
-    const val = +event.target.value;
-    if (val != autoClickCalcDamageDisplayMode && [0, 1].includes(val)) {
-        autoClickCalcDamageDisplayMode = val;
-        localStorage.setItem('autoClickCalcDamageDisplayMode', autoClickCalcDamageDisplayMode);
-        resetCalculator();
-    }
-}
-
-/* Auto Clicker */
-
-/**
- * Resets and, if enabled, restarts autoclicker
- * -While enabled, clicks <ticksPerSecond> times per second in active battle
- * -Outside battles, runs Auto Dungeon and Auto Gym
- */
-function autoClicker() {
-    var delay = Math.ceil(1000 / ticksPerSecond);
-    clearInterval(autoClickerLoop);
-    // Restart stats calculator
-    calcClickStats();
-    // Only use click multiplier while autoclicking
-    overrideClickAttack(autoClickState() ? autoClickMultiplier : 1);
-    if (autoClickState()) {
-        // Start autoclicker loop
-        autoClickerLoop = setInterval(function () {
-            // Click while in a normal battle
-            if (App.game.gameState === GameConstants.GameState.fighting) {
-                Battle.clickAttack(autoClickMultiplier);
-            }
-            // ...or gym battle
-            else if (App.game.gameState === GameConstants.GameState.gym) {
-                GymBattle.clickAttack(autoClickMultiplier);
-            }
-            // ...or dungeon battle
-            else if (App.game.gameState === GameConstants.GameState.dungeon && DungeonRunner.fighting()) {
-                DungeonBattle.clickAttack(autoClickMultiplier);
-            }
-            // ...or temporary battle
-            else if (App.game.gameState === GameConstants.GameState.temporaryBattle) {
-                TemporaryBattleBattle.clickAttack(autoClickMultiplier);
-            }
-            // If not battling, progress through dungeon
-            else if (autoDungeonState()) {
-                autoDungeon();
-            }
-            // If not battling gym, start battling
-            else if (autoGymState()) {
-                autoGym();
-            }
-            autoClickCalcTracker.ticks[0]++;
-        }, delay);
-    } else {
-        if (autoGymState()) {
-            GymRunner.autoRestart(false);
-        }
-    }
-}
-
-/**
- * Override the game's function for Click Attack to:
- * - make multiple clicks at once via multiplier
- * - support changing the attack speed cap for higher tick speeds
- */
-function overrideClickAttack(clickMultiplier = 1) {
-    // Set delay based on the autoclicker's tick rate
-    // (lower to give setInterval some wiggle room)
-    var delay = Math.min(Math.ceil(1000 / ticksPerSecond) - 10, 50);
-    var clickDamageCached = 0;
-    var lastCached = 0;
-    Battle.clickAttack = function () {
-        // click attacks disabled and we already beat the starter
-        if (App.game.challenges.list.disableClickAttack.active() && player.regionStarters[GameConstants.Region.kanto]() != GameConstants.Starter.None) {
-            return;
-        }
-        const now = Date.now();
-        if (now - this.lastClickAttack < delay) {
-            return;
-        }
-        this.lastClickAttack = now;
-        if (!this.enemyPokemon()?.isAlive()) {
-            return;
-        }
-        // Avoid recalculating damage 20 times per second
-        if (now - lastCached > 1000) {
-            clickDamageCached = App.game.party.calculateClickAttack(true);
-            lastCached = now;
-        }
-        // Don't autoclick more than needed for lethal
-        var clicks = Math.min(clickMultiplier, Math.ceil(this.enemyPokemon().health() / clickDamageCached));
-        GameHelper.incrementObservable(App.game.statistics.clickAttacks, clicks);
-        this.enemyPokemon().damage(clickDamageCached * clicks);
-        if (!this.enemyPokemon().isAlive()) {
-            this.defeatPokemon();
-        }
-    }
-}
-
-
-/* Auto Gym */
-
-/**
- * Starts selected gym with auto restart enabled
- */
-function autoGym() {
-    if (App.game.gameState === GameConstants.GameState.town) {
-        // Find all unlocked gyms in the current town
-        var gymList = player.town().content.filter((c) => (c.constructor.name == "Gym" && c.isUnlocked()));
-        if (gymList.length > 0) {
-            var gymIndex = Math.min(autoGymSelect, gymList.length - 1);
-            // Start in auto restart mode
-            GymRunner.startGym(gymList[gymIndex], true);
-            return;
-        }
-    }
-    // Disable if we aren't in a location with unlocked gyms
-    toggleAutoGym();
-}
-
-/**
- * Override GymRunner built-in functions:
- * -Add auto gym equivalent of gymWon() to save on performance by not loading town between
- */
-function overrideGymRunner() {
-    GymRunner.gymWonNormal = GymRunner.gymWon;
-    // Version with free auto restart
-    GymRunner.gymWonAuto = function(gym) {
-        if (GymRunner.running()) {
-            GymRunner.running(false);
-            // First time defeating this gym
-            if (!App.game.badgeCase.hasBadge(gym.badgeReward)) {
-                gym.firstWinReward();
-            }
-            GameHelper.incrementObservable(App.game.statistics.gymsDefeated[GameConstants.getGymIndex(gym.town)]);
-            // Award money for defeating gym as we're auto clicking
-            App.game.wallet.gainMoney(gym.moneyReward);
-
-            if (GymRunner.autoRestart()) {
-                // Unlike the original function, autoclicker doesn't charge the player money
-                GymRunner.startGym(GymRunner.gymObservable(), GymRunner.autoRestart(), false);
-                return;
-            }
-
-            // Send the player back to the town they were in
-            player.town(gym.parent);
-            App.game.gameState = GameConstants.GameState.town;
-        }
-    }
-    // Only use our version when auto gym is running
-    GymRunner.gymWon = function(...args) {
-        if (autoClickState() && autoGymState()) {
-            GymRunner.gymWonAuto(...args);
-        } else {
-            GymRunner.gymWonNormal(...args);
-        }
-    }
-}
-
-/* Auto Dungeon */
-
-/**
- * Automatically begins and progresses through dungeons with multiple pathfinding options
- */
-function autoDungeon() { // TODO more thoroughly test switching between modes and enabling/disabling within a dungeon
-    // Progress through dungeon
-    if (App.game.gameState === GameConstants.GameState.dungeon) {
-        if (DungeonRunner.fighting() || DungeonBattle.catching()) {
-            return;
-        }
-        // Scan each new dungeon floor
-        if (autoDungeonTracker.ID !== DungeonRunner.dungeonID || autoDungeonTracker.floor !== DungeonRunner.map.playerPosition().floor) {
-            scanDungeon();
-        }
-        // Reset pathfinding coordinates to entrance
-        if (autoDungeonTracker.coords == null) {
-            autoDungeonTracker.coords = new Point(Math.floor(autoDungeonTracker.floorSize / 2), autoDungeonTracker.floorSize - 1, autoDungeonTracker.floor);
-        }
-        const floorMap = DungeonRunner.map.board()[autoDungeonTracker.floor];
-
-        // All targets visible, fight enemies / open chests then finish floor
-        if (floorMap[autoDungeonTracker.bossCoords.y][autoDungeonTracker.bossCoords.x].isVisible &&
-            !((autoDungeonChestMode || autoDungeonEncounterMode) && !autoDungeonTracker.floorExplored)) {
-            clearDungeon();
-        }
-        // Explore dungeon to reveal boss + any target tiles
-        else {
-            exploreDungeon();
-        }
-    }
-    // Begin dungeon
-    else if (App.game.gameState === GameConstants.GameState.town) {
-        if (player.town() instanceof DungeonTown) {
-            const dungeon = player.town().dungeon;
-            // Enter dungeon if unlocked and affordable
-            if (dungeon?.isUnlocked() && App.game.wallet.hasAmount(new Amount(dungeon.tokenCost, GameConstants.Currency.dungeonToken))) {
-                DungeonRunner.initializeDungeon(dungeon);
-                return;
-            }
-        }
-        // Disable if locked, can't afford entry cost, or there's no dungeon here
-        toggleAutoDungeon();
-    }
-}
-
-/**
- * Scans current dungeon floor for relevant locations and pathfinding data
- */
-function scanDungeon() {
-    // Reset / update tracker values
-    autoDungeonTracker.ID = DungeonRunner.dungeonID;
-    autoDungeonTracker.floor = DungeonRunner.map.playerPosition().floor;
-    autoDungeonTracker.floorSize = DungeonRunner.map.floorSizes[DungeonRunner.map.playerPosition().floor];
-    autoDungeonTracker.encounterCoords = [];
-    autoDungeonTracker.chestCoords = [];
-    autoDungeonTracker.coords = null;
-    autoDungeonTracker.targetCoords = null;
-    autoDungeonTracker.floorExplored = false;
-    autoDungeonTracker.floorFinished = false;
-
-    // Scan for chest and boss coordinates
-    var dungeonBoard = DungeonRunner.map.board()[autoDungeonTracker.floor];
-    for (var y = 0; y < dungeonBoard.length; y++) {
-        for (var x = 0; x < dungeonBoard[y].length; x++) {
-            let tile = dungeonBoard[y][x];
-            if (tile.type() == GameConstants.DungeonTile.enemy) {
-                autoDungeonTracker.encounterCoords.push(new Point(x, y, autoDungeonTracker.floor));
-            } else if (tile.type() == GameConstants.DungeonTile.chest) {
-                let lootTier = Object.keys(baseLootTierChance).indexOf(tile.metadata.tier);
-                autoDungeonTracker.chestCoords.push({'xy': new Point(x, y, autoDungeonTracker.floor), 'tier': lootTier});
-            } else if (tile.type() == GameConstants.DungeonTile.boss || tile.type() == GameConstants.DungeonTile.ladder) {
-                autoDungeonTracker.bossCoords = new Point(x, y, autoDungeonTracker.floor);
-            }
-        }
-    }
-    // Sort chests by descending rarity
-    autoDungeonTracker.chestCoords.sort((a, b) => b.tier - a.tier);
-
-    // TODO find a more future-proof way to get flash distance
-    autoDungeonTracker.flashTier = DungeonFlash.tiers.findIndex(tier => tier === DungeonRunner.map.flash);
-    autoDungeonTracker.flashCols = [];
-    let flashRadius = DungeonRunner.map.flash?.playerOffset[0] ?? 0;
-    // Calculate minimum columns to fully reveal dungeon with Flash
-    if (flashRadius > 0) {
-        let cols = new Set();
-        cols.add(flashRadius);
-        let i = autoDungeonTracker.floorSize - flashRadius - 1;
-        while (i > flashRadius) {
-            cols.add(i);
-            i -= flashRadius * 2 + 1;
-        }
-        autoDungeonTracker.flashCols = [...cols].sort();
-    }
-}
-
-/**
- * Explores dungeon to reveal tiles, skipping columns that can be efficiently revealed by Flash
- */
-function exploreDungeon() {
-    const dungeonBoard = DungeonRunner.map.board()[autoDungeonTracker.floor];
-    var hasMoved = false;
-    while (!hasMoved) {
-        // End of column, move to start of new column
-        if (autoDungeonTracker.coords.y == 0) {
-            autoDungeonTracker.coords.y = autoDungeonTracker.floorSize - 1;
-            if (autoDungeonTracker.coords.x >= autoDungeonTracker.floorSize - 1 || autoDungeonTracker.coords.x === autoDungeonTracker.flashCols.at(-1)) {
-                // Done with this side, move to other side of the entrance
-                autoDungeonTracker.coords.x = Math.floor(autoDungeonTracker.floorSize / 2) - 1;
-            } else if (autoDungeonTracker.coords.x == 0 || autoDungeonTracker.coords.x === autoDungeonTracker.flashCols[0]) {
-                // Done exploring, clearDungeon() will take over from here
-                autoDungeonTracker.floorExplored = true;
-                return;
-            } else {
-                // Move away from the entrance
-                autoDungeonTracker.coords.x += (autoDungeonTracker.coords.x >= Math.floor(autoDungeonTracker.floorSize / 2) ? 1 : -1);
-            }
-        // Dungeon has Flash unlocked, skip columns not in optimal flash pathing
-        } else if (autoDungeonTracker.flashTier > -1
-            && autoDungeonTracker.coords.y == (autoDungeonTracker.floorSize - 1)
-            && !autoDungeonTracker.flashCols.includes(autoDungeonTracker.coords.x)) {
-            // Move one column further from the entrance
-            autoDungeonTracker.coords.x += (autoDungeonTracker.coords.x >= Math.floor(autoDungeonTracker.floorSize / 2) ? 1 : -1);
-        }
-        // Move through current column
-        else {
-            autoDungeonTracker.coords.y -= 1;
-        }
-        // One move per tick to look more natural
-        if (!dungeonBoard[autoDungeonTracker.coords.y][autoDungeonTracker.coords.x].isVisited) {
-            DungeonRunner.map.moveToCoordinates(autoDungeonTracker.coords.x, autoDungeonTracker.coords.y);
-            hasMoved = true;
-        }
-    }
-}
-
-/**
- * Clears dungeon, visiting all desired tile types. Assumes dungeon has already been explored to reveal desired tiles.
- */
-function clearDungeon() {
-    const dungeonBoard = DungeonRunner.map.board()[autoDungeonTracker.floor];
-    var hasMoved = false;
-    var stuckInLoopCounter = 0;
-    while (!hasMoved) {
-        // Choose a tile to move towards
-        if (!autoDungeonTracker.targetCoords) {
-            autoDungeonTracker.targetCoords = chooseDungeonTargetTile();
-        }
-        autoDungeonTracker.coords = pathfindTowardDungeonTarget();
-        if (!autoDungeonTracker.coords) {
-            console.warn(`Auto Dungeon could not find path to target tile \'${GameConstants.DungeonTile[dungeonBoard[autoDungeonTracker.targetCoords.y][autoDungeonTracker.targetCoords.x].type()]}\' (${autoDungeonTracker.targetCoords.x}, ${autoDungeonTracker.targetCoords.y})`);
-            toggleAutoDungeon();
-            return;
-        }
-        // One move per tick to look more natural
-        if (!(dungeonBoard[autoDungeonTracker.coords.y][autoDungeonTracker.coords.x] === DungeonRunner.map.currentTile())) {
-            DungeonRunner.map.moveToCoordinates(autoDungeonTracker.coords.x, autoDungeonTracker.coords.y);
-            hasMoved = true;
-        }
-        // Target tile reached
-        if (autoDungeonTracker.coords.x === autoDungeonTracker.targetCoords.x && autoDungeonTracker.coords.y === autoDungeonTracker.targetCoords.y) {
-            autoDungeonTracker.targetCoords = null;
-            hasMoved = true;
-            // Take corresponding action
-            const tileType = DungeonRunner.map.currentTile().type();
-            if (tileType === GameConstants.DungeonTile.enemy) {
-                // Do nothing, fights begin automatically
-            } else if (tileType === GameConstants.DungeonTile.chest) {
-                DungeonRunner.openChest();
-            } else if (tileType === GameConstants.DungeonTile.boss) {
-                if (autoDungeonTracker.floorFinished) {
-                    DungeonRunner.startBossFight();
-                }
-            } else if (tileType === GameConstants.DungeonTile.ladder) {
-                if (autoDungeonTracker.floorFinished) {
-                    DungeonRunner.nextFloor();
-                }
-            } else {
-                console.warn(`Auto Dungeon targeted tile type ${GameConstants.DungeonTile[tileType]}`);
-            }
-        }
-        stuckInLoopCounter++;
-        if (stuckInLoopCounter > 5) {
-            console.warn(`Auto Dungeon got stuck in a loop while moving to tile \'${GameConstants.DungeonTile[dungeonBoard[autoDungeonTracker.targetCoords.y][autoDungeonTracker.targetCoords.x].type()]}\' (${autoDungeonTracker.targetCoords.x}, ${autoDungeonTracker.targetCoords.y})`);
-            toggleAutoDungeon();
-            return;
-        }
-    }
-}
-
-function chooseDungeonTargetTile() {
-    const dungeonBoard = DungeonRunner.map.board()[autoDungeonTracker.floor];
-    let target = null;
-    while (!target) {
-        // Boss tile not yet unlocked
-        if (!dungeonBoard[autoDungeonTracker.bossCoords.y][autoDungeonTracker.bossCoords.x].isVisited) {
-            target = autoDungeonTracker.bossCoords;
-        }
-        // Encounters to fight
-        else if (autoDungeonEncounterMode && autoDungeonTracker.encounterCoords.length) {
-            // Skip already-fought encounters
-            let encounter = autoDungeonTracker.encounterCoords.pop();
-            if (dungeonBoard[encounter.y][encounter.x].type() == GameConstants.DungeonTile.enemy) {
-                target = encounter;
-            } else {
-                continue;
-            }
-        }
-        // Chests to open
-        else if (autoDungeonChestMode && autoDungeonTracker.chestCoords.length && autoDungeonTracker.chestCoords[0].tier >= autoDungeonLootTier) {
-            target = autoDungeonTracker.chestCoords.shift().xy;
-        }
-        // Open visible chests of sufficient rarity
-        else if (autoDungeonAlwaysOpenRareChests && autoDungeonTracker.chestCoords.some((c) => c.tier >= autoDungeonLootTier && dungeonBoard[c.xy.y][c.xy.x].isVisible)) {
-            let index = autoDungeonTracker.chestCoords.findIndex((c) => c.tier >= autoDungeonLootTier && dungeonBoard[c.xy.y][c.xy.x].isVisible);
-            target = autoDungeonTracker.chestCoords[index].xy;
-            autoDungeonTracker.chestCoords.splice(index, 1);
-        }
-        // Time to fight the boss
-        else {
-            target = autoDungeonTracker.bossCoords;
-            autoDungeonTracker.floorFinished = true;
-        }
-    }
-    return target;
-}
-
-/** 
- * Find next tile on the shortest path towards target via breadth-first search
- */
-function pathfindTowardDungeonTarget() {
-    const target = autoDungeonTracker.targetCoords;
-    let result = null;
-    if (!target) {
-        return result;
-    }
-    const queue = [target];
-    const visited = new Set(`${target.x}-${target.y}`);
-    while (queue.length) {
-        const p = queue.shift();
-        if (DungeonRunner.map.hasAccessToTile(p)) {
-            result = p;
-            break;
-        }
-        const adjTiles = [[p.x - 1, p.y], [p.x + 1, p.y], [p.x, p.y - 1], [p.x, p.y + 1]];
-        for (let [nx, ny] of adjTiles) {
-            // Enqueue valid tiles not yet considered
-            let xy = `${nx}-${ny}`;
-            if (0 <= nx && nx < autoDungeonTracker.floorSize && 0 <= ny && ny < autoDungeonTracker.floorSize && !visited.has(xy)) {
-                queue.push(new Point(nx, ny, target.floor));
-                visited.add(xy);
-            }
-        }
-    }
-    return result;
-}
-
-/**
- * Override DungeonRunner built-in functions*:
- * -Add dungeon ID tracking to initializeDungeon() for easier mapping
- * -Add auto dungeon equivalent of dungeonWon() to save on performance by restarting without loading town
- */
-function overrideDungeonRunner() {
-    // Differentiate between dungeons for mapping
-    DungeonRunner.dungeonID = 0;
-    const oldInit = DungeonRunner.initializeDungeon.bind(DungeonRunner);
-    DungeonRunner.initializeDungeon = function (...args) {
-        DungeonRunner.dungeonID++;
-        return oldInit(...args);
-    }
-
-    DungeonRunner.dungeonWonNormal = DungeonRunner.dungeonWon;
-    // Version with integrated auto-restart to avoid loading town in between dungeons
-    DungeonRunner.dungeonWonAuto = function () {
-        if (!DungeonRunner.dungeonFinished()) {
-            DungeonRunner.dungeonFinished(true);
-            // First time clearing dungeon
-            if (!App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]()) {
-                DungeonRunner.dungeon.rewardFunction();
-            }
-            GameHelper.incrementObservable(App.game.statistics.dungeonsCleared[GameConstants.getDungeonIndex(DungeonRunner.dungeon.name)]);
-
-            // Auto restart dungeon
-            if (DungeonRunner.hasEnoughTokens()) {
-                // Clear old board to force map visuals refresh
-                DungeonRunner.map.board([]);
-                DungeonRunner.initializeDungeon(DungeonRunner.dungeon);
-                return;
-            }
-
-            MapHelper.moveToTown(DungeonRunner.dungeon.name);
-        }
-    }
-    // Only use our version when auto dungeon is running
-    DungeonRunner.dungeonWon = function (...args) {
-        if (autoClickState() && autoDungeonState()) {
-            DungeonRunner.dungeonWonAuto(...args);
-        } else {
-            DungeonRunner.dungeonWonNormal(...args);
-        }
-    }
-}
-
-/* Clicker statistics calculator */
-
-/**
- * Resets and, if auto clicker is running, restarts calculator
- * Shows the following statistics, averaged over the last ten seconds:
- * -Percentage of ticksPerSecond the autoclicker is actually executing
- * -Clicks per second or damage per second, depending on display mode
- * -Required number of clicks or click attack damage to one-shot the current location, depending on display mode
- * --Ignores dungeon bosses and chest health increases
- * -Enemies defeated per second
- * Statistics are reset when the player changes locations
- */
-function calcClickStats() {
-    clearInterval(autoClickCalcLoop);
-    resetCalculator();
-    if (autoClickState()) {
-        autoClickCalcLoop = setInterval(function () {
-            if (!hasPlayerMoved()) {
-                var elem;
-                var clickDamage = App.game.party.calculateClickAttack(true);
-                var actualElapsed = (Date.now() - autoClickCalcTracker.lastUpdate.at(-1)) / (1000 * autoClickCalcTracker.lastUpdate.length);
-
-
-                // Percentage of maximum ticksPerSecond
-                elem = document.getElementById('tick-efficiency');
-                var avgTicks = autoClickCalcTracker.ticks.reduce((a, b) => a + b, 0) / autoClickCalcTracker.ticks.length;
-                avgTicks = avgTicks / actualElapsed;
-                if (autoClickCalcEfficiencyDisplayMode == 1) {
-                    // display ticks mode
-                    elem.innerHTML = avgTicks.toLocaleString('en-US', {maximumFractionDigits: 1} );
-                    elem.style.color = 'gold';
-                } else {
-                    // display percentage mode
-                    var tickFraction = avgTicks / ticksPerSecond;
-                    elem.innerHTML = tickFraction.toLocaleString('en-US', {style: 'percent', maximumFractionDigits: 0} );
-                    elem.style.color = 'gold';
-                }
-
-                // Average clicks/damage per second
-                elem = document.getElementById('clicks-per-second');
-                var avgClicks = (App.game.statistics.clickAttacks() - autoClickCalcTracker.clicks.at(-1)) / autoClickCalcTracker.clicks.length;
-                avgClicks = avgClicks / actualElapsed;
-                if (autoClickCalcDamageDisplayMode == 1) {
-                    // display damage mode
-                    var avgDPS = avgClicks * clickDamage;
-                    elem.innerHTML = avgDPS.toLocaleString('en-US', {maximumFractionDigits: 0});
-                    elem.style.color = 'gold';
-                } else {
-                    // display click attacks mode
-                    elem.innerHTML = avgClicks.toLocaleString('en-US', {maximumFractionDigits: 1});
-                    elem.style.color = 'gold';
-                }
-
-                // Required clicks/click damage
-                elem = document.getElementById('req-clicks');
-                if (autoClickCalcTracker.areaHealth == 0) {
-                    // can't meaningfully calculate a value for this area/game state
-                    elem.innerHTML = '-';
-                    elem.style.removeProperty('color');
-                } else if (autoClickCalcDamageDisplayMode == 1) {
-                    // display damage mode
-                    var reqDamage = autoClickCalcTracker.areaHealth;
-                    elem.innerHTML = reqDamage.toLocaleString('en-US');
-                    elem.style.color = (clickDamage * autoClickMultiplier >= reqDamage ? 'greenyellow' : 'darkred');
-                } else {
-                    // display clicks mode
-                    var reqClicks = Math.max((autoClickCalcTracker.areaHealth / clickDamage), 1);
-                    reqClicks = Math.ceil(reqClicks * 10) / 10; // round up to one decimal point
-                    elem.innerHTML = reqClicks.toLocaleString('en-US', {maximumFractionDigits: 1});
-                    elem.style.color = (reqClicks <= autoClickMultiplier ? 'greenyellow' : 'darkred');
-                }
-
-                // Enemies per second
-                elem = document.getElementById('enemies-per-second');
-                var avgEnemies = (App.game.statistics.totalPokemonDefeated() - autoClickCalcTracker.enemies.at(-1)) / autoClickCalcTracker.enemies.length;
-                avgEnemies = avgEnemies / actualElapsed;
-                elem.innerHTML = avgEnemies.toLocaleString('en-US', {maximumFractionDigits: 1});
-                elem.style.color = 'gold';
-
-                // Make room for next second's stats tracking
-                // Add new entries to start of array for easier incrementing
-                autoClickCalcTracker.ticks.unshift(0);
-                if (autoClickCalcTracker.ticks.length > 10) {
-                    autoClickCalcTracker.ticks.pop();
-                }
-                autoClickCalcTracker.clicks.unshift(App.game.statistics.clickAttacks());
-                if (autoClickCalcTracker.clicks.length > 10) {
-                    autoClickCalcTracker.clicks.pop();
-                }
-                autoClickCalcTracker.enemies.unshift(App.game.statistics.totalPokemonDefeated());
-                if (autoClickCalcTracker.enemies.length > 10) {
-                    autoClickCalcTracker.enemies.pop();
-                }
-                autoClickCalcTracker.lastUpdate.unshift(Date.now());
-                if (autoClickCalcTracker.lastUpdate.length > 10) {
-                    autoClickCalcTracker.lastUpdate.pop();
-                }
-            }
-            // Reset statistics on area / game state change
-            else {
-                resetCalculator();
-            }
-        }, 1000);
-    }
-}
-
-
-/**
- * Resets stats trackers and calculator info display
- */
-function resetCalculator() {
-    autoClickCalcTracker.lastUpdate = [Date.now()];
-    autoClickCalcTracker.ticks = [0];
-    autoClickCalcTracker.clicks = [App.game.statistics.clickAttacks()];
-    autoClickCalcTracker.enemies = [App.game.statistics.totalPokemonDefeated()];
-    playerTown = player.town().name;
-    playerRoute = player.route();
-    calculateAreaHealth();
-    document.getElementById('auto-click-info').innerHTML = `<div>${autoClickCalcEfficiencyDisplayMode == 0 ? 'Clicker Efficiency' : 'Ticks/s'}:<br><div id="tick-efficiency" style="font-weight:bold;">-</div></div>
-        <div>${autoClickCalcDamageDisplayMode == 0 ? 'Click Attacks/s' : 'DPS'}:<br><div id="clicks-per-second" style="font-weight:bold;">-</div></div>
-        <div>Req. ${autoClickCalcDamageDisplayMode == 0 ? 'Clicks' : 'Click Damage'}:<br><div id="req-clicks" style="font-weight:bold;">-</div></div>
-        <div>Enemies/s:<br><div id="enemies-per-second" style="font-weight:bold;">-</div></div>`;
-}
-
-
-/**
- * Check whether player state or location has changed
- */
-function hasPlayerMoved() {
-    var moved = false;
-    if (autoClickCalcTracker.playerState != App.game.gameState) {
-        autoClickCalcTracker.playerState = App.game.gameState;
-        moved = true;
-    }
-    if (autoClickCalcTracker.playerState === GameConstants.GameState.gym) {
-        if (autoClickCalcTracker.playerLocation != GymRunner.gymObservable().leaderName) {
-            moved = true;
-        }
-        autoClickCalcTracker.playerLocation = GymRunner.gymObservable().leaderName;
-    } else if (autoClickCalcTracker.playerState === GameConstants.GameState.dungeon) {
-        if (autoClickCalcTracker.playerLocation != DungeonRunner.dungeon.name) {
-            moved = true;
-        }
-        autoClickCalcTracker.playerLocation = DungeonRunner.dungeon.name;
-    } else if (autoClickCalcTracker.playerState === GameConstants.GameState.temporaryBattle) {
-        if (autoClickCalcTracker.playerLocation != TemporaryBattleRunner.battleObservable().name) {
-            moved = true;
-        }
-        autoClickCalcTracker.playerLocation = TemporaryBattleRunner.battleObservable().name;
-    } else {
-        // Conveniently, player.route() = 0 when not on a route
-        if (autoClickCalcTracker.playerLocation != (player.route() || player.town().name)) {
-            moved = true;
-        }
-        autoClickCalcTracker.playerLocation = player.route() || player.town().name;
-    }
-    return moved;
-}
-
-/**
- * Calculate max Pokemon health for the current route/gym/dungeon
- * -Ignores dungeon boss HP and chest HP increases
- */
-function calculateAreaHealth() {
-    // Calculate area max hp
-    if (App.game.gameState === GameConstants.GameState.fighting) {
-        autoClickCalcTracker.areaHealth = PokemonFactory.routeHealth(player.route(), player.region);
-        // Adjust for route health variation (adapted from PokemonFactory.generateWildPokemon)
-        const pokeHP = [...new Set(Object.values(Routes.getRoute(player.region, player.route()).pokemon).flat().flatMap(p => p.pokemon ?? p))].map(p => pokemonMap[p].base.hitpoints);
-        const averageHP = pokeHP.reduce((s, a) => s + a, 0) / pokeHP.length;
-        const highestHP = pokeHP.reduce((m, a) => Math.max(m, a), 0);
-        autoClickCalcTracker.areaHealth = Math.round(autoClickCalcTracker.areaHealth * (0.9 + (highestHP / averageHP) / 10));
-    } else if (App.game.gameState === GameConstants.GameState.gym) {
-        // Get highest health gym pokemon
-        autoClickCalcTracker.areaHealth = GymRunner.gymObservable().getPokemonList().reduce((a, b) => Math.max(a, b.maxHealth), 0);
-    } else if (App.game.gameState === GameConstants.GameState.dungeon) {
-        autoClickCalcTracker.areaHealth = DungeonRunner.dungeon.baseHealth;
-    } else if (App.game.gameState === GameConstants.GameState.temporaryBattle) {
-        // Get highest health trainer pokemon
-        autoClickCalcTracker.areaHealth = TemporaryBattleRunner.battleObservable().getPokemonList().reduce((a, b) => Math.max(a, b.maxHealth), 0);
-    } else {
-        autoClickCalcTracker.areaHealth = 0;
-    }
-}
-
-/* Graphics settings */
-
-/**
- * Add extra Knockout data bindings to optionally disable (most) gym and dungeon graphics
- */
-function addGraphicsBindings() {
-    // Add computed observable functions
-    GymRunner.autoGymOn = ko.pureComputed( () => {
-        return autoClickState() && autoGymState();
-    });
-    GymRunner.disableAutoGymGraphics = ko.pureComputed( () => {
-        return gymGraphicsDisabled() && GymRunner.autoGymOn();
-    });
-    DungeonRunner.disableAutoDungeonGraphics = ko.pureComputed( () => {
-        return dungeonGraphicsDisabled() && autoClickState() && autoDungeonState();
-    });
-
-    // Add gymView data bindings
-    var gymContainer = document.querySelector('div[data-bind="if: App.game.gameState === GameConstants.GameState.gym"]');
-    var elemsToBind = ['knockout[data-bind*="pokemonNameTemplate"]', // Pokemon name
-        'span[data-bind*="pokemonsDefeatedComputable"]', // Gym Pokemon counter (pt 1)
-        'span[data-bind*="pokemonsUndefeatedComputable"]', // Gym Pokemon counter (pt 2)
-        'knockout[data-bind*="pokemonSpriteTemplate"]', // Pokemon sprite
-        'div.progress.hitpoints', // Pokemon healthbar
-        'div.progress.timer' // Gym timer
-        ];
-    elemsToBind.forEach((query) => {
-        var elem = gymContainer.querySelector(query);
-        if (elem) {
-            elem.before(new Comment("ko ifnot: GymRunner.disableAutoGymGraphics()"));
-            elem.after(new Comment("/ko"));
-        }
-    });
-    // Always hide stop button during autoGym, even with graphics enabled
-    var restartButton = gymContainer.querySelector('button[data-bind="visible: GymRunner.autoRestart()"]');
-    restartButton.setAttribute('data-bind', 'visible: GymRunner.autoRestart() && !GymRunner.autoGymOn()');
-
-    // Add dungeonView data bindings
-    var dungeonContainer = document.querySelector('div[data-bind="if: App.game.gameState === GameConstants.GameState.dungeon"]');
-    // Title bar contents
-    dungeonContainer.querySelector('h2.pageItemTitle')?.prepend(new Comment("ko ifnot: DungeonRunner.disableAutoDungeonGraphics()"));
-    dungeonContainer.querySelector('h2.pageItemTitle')?.append(new Comment("/ko"));
-    // Main container sprites etc
-    dungeonContainer.querySelector('h2.pageItemTitle')?.after(new Comment("ko ifnot: DungeonRunner.disableAutoDungeonGraphics()"));
-    dungeonContainer.querySelector('h2.pageItemFooter')?.before(new Comment("/ko"));
-}
-
-/* Initializing variables from localStorage */
-
-/**
- * Loads variable from localStorage
- * -Returns value from localStorage if it exists and is correct type
- * -Otherwise returns null
- */
-function validateStorage(key, type) {
-    try {
-        var val = localStorage.getItem(key);
-        val = JSON.parse(val);
-        if (val == null || typeof val !== type) {
-            throw new Error();
-        }
-        return val;
-    } catch (e) {
-        return null;
-    }
-}
-
-// Auto Clicker
-autoClickState(validateStorage('autoClickState', 'boolean') ?? false);
-autoClickMultiplier = validateStorage('autoClickMultiplier', 'number') ?? 1;
-if (!(Number.isInteger(autoClickMultiplier) && autoClickMultiplier >= 1)) {
-    autoClickMultiplier = 1;
-}
-
-// Auto Gym
-autoGymState(validateStorage('autoGymState', 'boolean') ?? false);
-autoGymSelect = validateStorage('autoGymSelect', 'number') ?? 0;
-if (![0, 1, 2, 3, 4].includes(autoGymSelect)) {
-    autoGymSelect = 0;
-}
-
-// Auto Dungeon
-autoDungeonState(validateStorage('autoDungeonState', 'boolean') ?? false);
-autoDungeonEncounterMode = validateStorage('autoDungeonEncounterMode', 'boolean') ?? false;
-autoDungeonChestMode = validateStorage('autoDungeonEncounterMode', 'boolean') ?? false;
-autoDungeonAlwaysOpenRareChests = validateStorage('autoDungeonAlwaysOpenRareChests', 'boolean') ?? false;
-autoDungeonLootTier = validateStorage('autoDungeonLootTier', 'number') ?? -1;
-if(![-1, ...Object.keys(baseLootTierChance).keys()].includes(autoDungeonLootTier)) {
-    autoDungeonLootTier = -1;
-}
-
-// Stats calculator
-autoClickCalcEfficiencyDisplayMode = validateStorage('autoClickCalcEfficiencyDisplayMode', 'number') ?? 0;
-if (![0, 1].includes(autoClickCalcEfficiencyDisplayMode)) {
-    autoClickCalcEfficiencyDisplayMode = 0;
-}
-autoClickCalcDamageDisplayMode = validateStorage('autoClickCalcDamageDisplayMode', 'number') ?? 0;
-if (![0, 1].includes(autoClickCalcDamageDisplayMode)) {
-    autoClickCalcDamageDisplayMode = 0;
-}
-
-// Graphics settings
-gymGraphicsDisabled(validateStorage('gymGraphicsDisabled', 'boolean') ?? false);
-dungeonGraphicsDisabled(validateStorage('dungeonGraphicsDisabled', 'boolean') ?? false);
-
-/* Load script */
-
-// Add data bindings before the game initializes Knockout
-addGraphicsBindings();
-
 function loadScript() {
     const oldInit = Preload.hideSplashScreen;
     var hasInitialized = false;
@@ -1137,11 +1091,13 @@ function loadScript() {
     Preload.hideSplashScreen = function (...args) {
         var result = oldInit.apply(this, args);
         if (App.game && !hasInitialized) {
-            initAutoClicker();
+            EnhancedAutoClicker.initAutoClicker();
             hasInitialized = true;
         }
         return result;
     }
+
+    EnhancedAutoClicker.initOverrides();
 }
 
 if (!App.isUsingClient || localStorage.getItem(scriptName) === 'true') {

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -35,7 +35,7 @@ class EnhancedAutoClicker {
     static autoDungeonState = ko.observable(validateStorage('autoDungeonState', false));
     static autoDungeonEncounterMode = validateStorage('autoDungeonEncounterMode', false);
     static autoDungeonChestMode = validateStorage('autoDungeonEncounterMode', false);
-    static autoDungeonLootTier = validateStorage('autoDungeonLootTier', -1, [-1, ...Object.keys(baseLootTierChance).keys()]);
+    static autoDungeonLootTier = validateStorage('autoDungeonLootTier', 0, Object.keys(baseLootTierChance).keys());
     static autoDungeonAlwaysOpenRareChests = validateStorage('autoDungeonAlwaysOpenRareChests', false);
     static autoDungeonTracker = {
         ID: 0,
@@ -125,11 +125,9 @@ class EnhancedAutoClicker {
                 <div style="flex: initial; display: flex; flex-direction: column;">
                     <div id="auto-dungeon-loottier" class="dropdown show">
                         <button type="button" class="text-left custom-select col-12 btn btn-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="max-height:30px; display:flex; flex:1; align-items:center;">
-                            <div id="auto-dungeon-loottier-text" ${this.autoDungeonLootTier > -1 ? 'style="display:none;"' : ''}>None</div>
-                            <img id="auto-dungeon-loottier-img" src="${this.autoDungeonLootTier > -1 ? `assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[this.autoDungeonLootTier]}.png` : ''}" style="height:100%; ${this.autoDungeonLootTier > -1 ? '' : 'display:none;'}">
+                            <img id="auto-dungeon-loottier-img" src="assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[this.autoDungeonLootTier]}.png" style="height:100%;">
                         </button>
                         <div id="auto-dungeon-loottier-dropdown" class="border-secondary dropdown-menu col-12">
-                            <div class="dropdown-item dropdown-text" value="-1">None</div>
                             ${Object.keys(baseLootTierChance).map((tier, i) => `<div class="dropdown-item" value="${i}"><img src="assets/images/dungeons/chest-${tier}.png"></div>` ).join('\n')}
                         </div>
                     </div>
@@ -337,17 +335,9 @@ class EnhancedAutoClicker {
 
     static changeAutoDungeonLootTier(tier) {
         const val = +tier;
-        if ([-1, ...Object.keys(baseLootTierChance).keys()].includes(val)) {
+        if (Object.keys(baseLootTierChance).keys().includes(val)) {
             this.autoDungeonLootTier = val;
-            if (val > -1) {
-                document.getElementById('auto-dungeon-loottier-img').setAttribute('src', `assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[val]}.png`);
-                document.getElementById('auto-dungeon-loottier-img').style.removeProperty('display');
-                document.getElementById('auto-dungeon-loottier-text').style.setProperty('display', 'none');
-            } else {
-                document.getElementById('auto-dungeon-loottier-img').setAttribute('src', '');
-                document.getElementById('auto-dungeon-loottier-img').style.setProperty('display', 'none');
-                document.getElementById('auto-dungeon-loottier-text').style.removeProperty('display');
-            }
+            document.getElementById('auto-dungeon-loottier-img').setAttribute('src', `assets/images/dungeons/chest-${Object.keys(baseLootTierChance)[val]}.png`);
             localStorage.setItem("autoDungeonLootTier", this.autoDungeonLootTier);
         }
     }

--- a/enhancedautomine.user.js
+++ b/enhancedautomine.user.js
@@ -80,9 +80,12 @@ function initAutoMine() {
     addGlobalStyle('#item-threshold { width:75px; }');
 
     if (mineState) {
-        autoMineTimer = setInterval(function () {
-            doAutoMine();
-        }, 1000);
+        // Wait a few seconds to not mine before underground is fully loaded
+        setTimeout(() => {
+            autoMineTimer = setInterval(function () {
+                doAutoMine();
+            }, 1000);
+        }, 5000);
     }
 }
 


### PR DESCRIPTION
- Enhanced Auto Clicker
  - Auto Dungeon now has separate fights and chests modes
    - Open all chests without fighting every enemy or vice versa
    - New setting to open rare chests when chests mode is off
  - Rewrote script to be a class and have fewer global variables cluttering things up
  - Closes #75, closes #140, closes #197
- Additional Visual Settings
  - Fixed the dock/gym/dungeon menus allowing some sequence breaking
- Auto Safari Zone
  - Now enabled in Johto's National Park and Sinnoh's Great Marsh
    - In National Park will default to highest-average-token encounter type
  - Improved prioritization between land and water encounters
  - Closes #354, closes #358
- Scripts with their own settings menus now display in a consistent alphabetical order
- Fixed a couple rare desktop issues
- Readme updates
  - Closes #353