### PR TITLE
Add Smart Mulch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,20 +297,23 @@ As of 1.1 this also includes 2 more additional features into the Treasures tab o
   
 <a name="simple-auto-farmer"></a>
 ## Simple Auto Farmer (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/blob/main/simpleautofarmer.user.js">simpleautofarmer.user.js</a>) (<a href="https://github.com/Ephenia/Pokeclicker-Scripts/raw/master/simpleautofarmer.user.js">One-Click Install</a>)
-This script is a simple Auto Farmer which adds 4 new buttons below the Plant and Harvest all buttons as shown:<br>
+This script is a simple Auto Farmer which adds 5 new buttons below the Plant and Harvest all buttons as shown:<br>
 
 ![](https://i.imgur.com/ei7lR95.png)
 
 • Auto Farm will plant the berry that you have selected.<br/>
 • Auto Harvest will harvest all ripe berries.<br/>
 • Auto Replant will wait for ripe berries to be close to withering before harvesting, then replant the same kind of berry in that plot. This can be especially useful for mutating berries.<br/>
-• Auto Mulch will wait for mulch to be close to running out, then use the same kind of mulch on that plot.
+• Auto Mulch will wait for mulch to be close to running out, then use the same kind of mulch on that plot.<br/>
+• Auto Smart Mulch will wait until the plot is ready to harvest, then apply rich mulch to increase the yield.
 
 The Auto Farmer runs even while the farm window is closed. It also now saves your berry selection when the game restarts, to avoid farming interruptions.
 
 ```diff
 - Note: the Auto Farmer runs once every 1 second.
 - Note: Auto Replant cannot be used alongside Auto Plant or Auto Harvest.
+- Note: Auto Smart Mulch cannot be used alongside Auto Mulch.
+- Note: Auto Smart Mulch requires Auto Harvest or Auto Replant to be active in order to function.
 ```
 
 <hr>

--- a/simpleautofarmer.user.js
+++ b/simpleautofarmer.user.js
@@ -5,7 +5,7 @@
 // @description   Adds options to automatically plant, harvest, replant, and remulch. Unlike harvesting, replanting only harvests berries right before they wither, to maximize any auras. Make sure the correct berry is selected before auto planting; the script will save your selection across restarts. Auto replant and mulch maintain the berry/mulch already in each plot.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.7
+// @version       1.8
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -27,11 +27,13 @@ function initAutoFarm() {
     var harvestState;
     var replantState;
     var mulchState;
+    var smartMulchState;
 
     plantState = JSON.parse(localStorage.getItem('autoPlantState'));
     harvestState = JSON.parse(localStorage.getItem('autoHarvestState'));
     replantState = JSON.parse(localStorage.getItem('autoReplantState'));
     mulchState = JSON.parse(localStorage.getItem('autoMulchState'));
+    smartMulchState = JSON.parse(localStorage.getItem('autoSmartMulchState'));
 
     let plantSelected = JSON.parse(localStorage.getItem('autoPlantSelected'));
     FarmController.selectedBerry(plantSelected);
@@ -79,6 +81,7 @@ function initAutoFarm() {
         createButton('harvest', harvestState, autoHarvestToggle, 'l', true);
         createButton('replant', replantState, autoReplantToggle, 'r', false);
         createButton('mulch', mulchState, autoMulchToggle, 'l', false);
+        createButton('smart-mulch', smartMulchState, autoSmartMulchToggle, 'r', false);
     }
 
     function toggleFarmLoop() {
@@ -150,6 +153,10 @@ function initAutoFarm() {
     }
 
     function doHarvest() {
+        if (smartMulchState){
+            //Applies rich mulch to all ripe plots
+            doSmartMulch()
+        }
         App.game.farming.harvestAll();
     }
 
@@ -185,6 +192,10 @@ function initAutoFarm() {
                 var timeLeft = berryData[berry].growthTime[4] - plot.age;
                 timeLeft /= (App.game.farming.getGrowthMultiplier() * plot.getGrowthMultiplier());
                 if (timeLeft < 10) {
+                    if (smartMulchState){
+                        // Applies rich mulch to the current plot
+                        doRipeMulch(plot)
+                    }
                     App.game.farming.harvest(i, false);
                     App.game.farming.plant(i, berry, false);
                 }
@@ -196,6 +207,9 @@ function initAutoFarm() {
         mulchState = !mulchState;
         localStorage.setItem("autoMulchState", mulchState);
         toggleFarmLoop();
+        if (smartMulchState) {
+            autoSmartMulchToggle();
+        }
         let elt = document.getElementById('auto-mulch-toggle');
         if (mulchState) {
             elt.innerText = "Auto Mulch\n[ON]";
@@ -215,6 +229,41 @@ function initAutoFarm() {
             if (plot.mulch != MulchType.None && plot.mulchTimeLeft < 15) {
                 App.game.farming.addMulch(i, plot.mulch);
             }
+        }
+    }
+
+    function autoSmartMulchToggle() {
+        smartMulchState = !smartMulchState;
+        localStorage.setItem("autoHarvestState", smartMulchState);
+        toggleFarmLoop();
+        if (mulchState) {
+            autoMulchToggle();
+        }
+        let elt = document.getElementById('auto-smart-mulch-toggle');
+        if (smartMulchState) {
+            // No \n because it causes clipping issues with the shovel button. "Auto Smart Mulch" takes up two lines
+            elt.innerText = "Auto Smart Mulch [ON]";
+            elt.classList.remove('btn-danger');
+            elt.classList.add('btn-success');
+        } else {
+            elt.innerText = "Auto Smart Mulch [OFF]";
+            elt.classList.remove('btn-success');
+            elt.classList.add('btn-danger');
+        }
+    }
+    // Checks each plot to see if it's ripe, then calls the function to apply rich mulch to that plot if it is ripe
+    function doSmartMulch(){
+        for (let i = 0; i < 25; i++) {
+            let plot = App.game.farming.plotList[i];
+            if (plot.berry >= 0 && plot.stage() == 4) {
+                doRipeMulch(plot)
+            }
+        }
+    }
+    // Checks if the given plot has no mulch, and if it doesn't, applies rich mulch
+    function doRipeMulch(plot){
+        if (plot.mulch == MulchType.None) {
+                App.game.farming.addMulch(plot.index, 1);
         }
     }
 }
@@ -271,6 +320,7 @@ initLocalStorage("autoPlantState", false);
 initLocalStorage("autoHarvestState", false);
 initLocalStorage("autoReplantState", false);
 initLocalStorage("autoMulchState", false);
+initLocalStorage("autoSmartMulchState", false);
 initLocalStorage("autoPlantSelected", 0);
 
 

--- a/simpleautofarmer.user.js
+++ b/simpleautofarmer.user.js
@@ -16,7 +16,7 @@
 // @icon          https://www.google.com/s2/favicons?domain=pokeclicker.com
 // @grant         none
 // @run-at        document-idle
-// ==/UserScript==//
+// ==/UserScript==
 
 var scriptName = 'simpleautofarmer';
 


### PR DESCRIPTION
This adds a new toggle to the Simple Auto Farmer script.
When enabled, it will apply Rich mulch to plots that are about to be harvested, as to maximise Rich Mulch usage and increase yield.
Only applies when Auto Harvest or Auto Replant are active, and toggles Auto Mulch off (and vice versa, like with Auto Harvest/Plant and Auto Replant).

This will also close #278 as it satisfies the request.

This could be improved so that it applies boost mulch until the plant is ripe (then applies Rich mulch when harvesting and shovelling before and after applying the rich mulch), but that was out of the scope of what I was planning to achieve for now.