### PR TITLE
Fix Badges Not Displaying in Gyms Shortcut Modal

### DIFF
--- a/additionalvisualsettings.user.js
+++ b/additionalvisualsettings.user.js
@@ -181,7 +181,7 @@ function initVisualSettings() {
         const regionGyms = Object.values(GymList).filter((gym) => gym.parent?.region === player.region);
         for (const gym of regionGyms) {
             const hasBadgeImage = !(BadgeEnums[gym.badgeReward].startsWith('Elite') || BadgeEnums[gym.badgeReward] == 'None');
-            const badgeImage = (hasBadgeImage ? `assets/images/badges/${BadgeEnums[gym.badgeReward]}.png` : '');
+            const badgeImage = (hasBadgeImage ? `assets/images/badges/${BadgeEnums[gym.badgeReward]}.svg` : '');
             const btn = document.createElement('button');
             btn.setAttribute('style', 'position: relative;');
             btn.setAttribute('class', 'btn btn-block btn-success');


### PR DESCRIPTION
Currently badges don't display when opening the gyms shortcut modal because `generateRegionGymsList` looks for ".png" files. Badge images seem to be stored as ".svg" files, so this commit makes `generateRegionGymsList` look for ".svg" files and thus allows badges to display in the gyms shortcut modal.