### PR TITLE
Fix Pokéball modal invisible background for v0.10.18

### DIFF
--- a/custom/catchspeedadjuster.user.js
+++ b/custom/catchspeedadjuster.user.js
@@ -5,7 +5,7 @@
 // @description   Adjusts catch speed of all Pokeballs. Currently only makes Pokeballs catch as fast as possible.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.3
+// @version       1.4
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -32,7 +32,6 @@ function initBallAdjust() {
     var ballAdj = document.createElement("tr");
     ballAdj.innerHTML = `<td colspan="3"><div style="height: 25px;"><label for="ball-adjust">0 Delay Capture <label><input id="ball-adjust" type="checkbox" style="position: relative;top: 2px;"></div></td>`
     ballCont.append(ballAdj)
-    document.getElementById('pokeballSelectorBody').style.maxHeight = "285px";
     document.getElementById('ball-adjust').addEventListener('click', event => changeAdjust(event.target));
 
     if (ballAdjuster) {


### PR DESCRIPTION
Small edit to the `catchspeedadjuster.user.js` file so the background for the Pokéball modal is not broken and invisible anymore after a certain size.

<table>
	<tr align="center">
		<td><b>Before fix</b></td>
		<td><b>After fix</b></td>
	</tr>
	<tr>
		<td><img src="https://i.imgur.com/jr4QIqU.png"></td>
		<td> <img src="https://i.imgur.com/LAGm1ql.png"></td>
	</tr>
</table>
