### PR TITLE
Fix Auto Fossil Hatch in v0.10.18

### DIFF
--- a/enhancedautohatchery.user.js
+++ b/enhancedautohatchery.user.js
@@ -5,7 +5,7 @@
 // @description   Automatically hatches eggs at 100% completion. Adds an On/Off button for auto hatching as well as an option for automatically hatching store bought eggs and dug up fossils.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       3.1
+// @version       3.1.1
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues

--- a/enhancedautohatchery.user.js
+++ b/enhancedautohatchery.user.js
@@ -232,9 +232,8 @@ function autoHatchEgg() {
 }
 
 function autoHatchFossil() {
-    let fossilList = Object.keys(GameConstants.FossilToPokemon);
     // Fossils in inventory with amount > 0
-    fossilList = fossilList.map(f => player.mineInventory().find(i => i.name == f && i.amount())).filter(f => f != undefined);
+    let fossilList = UndergroundItems.list.filter(it => it.valueType === UndergroundItemValueType.Fossil && player.itemList[it.itemName]() > 0);
     if (shinyFossilState) {
         // Fossils where the shiny is not yet obtained
         fossilList = fossilList.filter(f => PartyController.getCaughtStatusByName(GameConstants.FossilToPokemon[f.name]) != CaughtStatus.CaughtShiny);
@@ -245,7 +244,7 @@ function autoHatchFossil() {
     let fossilToUse = fossilList[Math.floor(Math.random() * fossilList.length)];
     // Workaround as sellMineItem returns null
     let before = App.game.breeding.eggList.reduce((count, e) => count + !e().isNone(), 0);
-    Underground.sellMineItem(fossilToUse.id);
+    Underground.sellMineItem(fossilToUse);
     let after = App.game.breeding.eggList.reduce((count, e) => count + !e().isNone(), 0);
     return before < after;
 }


### PR DESCRIPTION
`autoFossilHatch` is broken in v0.10.18 (as mentioned here https://github.com/Ephenia/Pokeclicker-Scripts/issues/373#issue-2092609196). It seems that the cause is this commit (https://github.com/pokeclicker/pokeclicker/commit/25d0376f8ddb5cb828afaa6b1b18ca8bb16e789a), which removed `player.mineInventory`.

This pull request simply fixes `autoFossilHatch` by filtering for fossils in `UndergroundItems.list`.