### PR TITLE
Additional Visual Settings rework for new update

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,9 @@ This script adds new options to customize the game's graphics alongside a handfu
 
 ### **Visual Settings**
 
-The added visual settings are found in the Scripts settings tab. Several of these new options are shown here:<br>
+The script's visual settings save on performance by disabling parts of the HTML that can change rapidly. There are settings for route battles, gym battles, dungeons, and the battle frontier. All of them can be found in the Scripts settings tab.
 
-![](https://i.imgur.com/sWlhKlx.png)
-
-I made these options as a hacky way to help save on some performance, especially when you are idling and leaving the game open for longer periods of time. This ends up removing these HTML elements that are constantly getting updated, so that the DOM is less flooded. After enabling any of these options, you will have to change routes for these settings to take effect. When disabling, you will have to go to something like a Town/Dungeon then back to a route for these to start working again.
-
-As of 1.3 there is now an option for disabling all notifications, this may be especially helpful if you are using Enhanced Auto Mine. This may also cause some popups and other things to not appear (such as trying to manually Skip layers in the Underground). You can still hear when you get shinies using this, but you won't be able to see what shiny you received. I have not fully tested this, so feel free to experiment with this setting.
+If the Enhanced Auto Clicker script is installed, an additional setting is available to only apply the above visual settings when the autoclicker is running. This lets you improve performance when grinding but still experience the game's graphics the rest of the time.
 
 ### **Convenience features**
 
@@ -231,15 +227,6 @@ The Auto Dungeon feature is found below the Auto Click button. Some notes about 
 &emsp;&emsp;• When neither mode is on (both buttons are greyed out), Auto Dungeon will just find and fight the boss as quickly as possible.<br>
 • The dropdown menu determines which chests Auto Dungeon will open. It will only open chests of the selected rarity or higher.<br>
 &emsp;&emsp;• If the settings menu option "Always open visible targeted chests" is enabled, Auto Dungeon will open chests of sufficient rarity even when chests mode is off. It will open any visible chests right before fighting the boss but not explore the floor to reveal potential other chests.<br>
-
-### **Graphics settings**
-
-The Auto Clicker now includes graphics settings for Auto Gym and Auto Dungeon to save on performance, similar to those in the Additional Visual Settings script. These settings are located along with the statistics display mode setting in the Visual Settings tab of the settings menu. These disable most gym graphics while Auto Gym is running and most dungeon graphics while Auto Dungeon is running, respectively.
-
-```diff
-- Note: the Auto Clicker runs every 0.05 seconds.
-- Note: statistics are checked and updated every 1 second while the Auto Clicker is active.
-```
 
 <hr>
 

--- a/additionalvisualsettings.user.js
+++ b/additionalvisualsettings.user.js
@@ -23,7 +23,6 @@ var wildPokeDefeatDisabled = ko.observable(false);
 var wildPokeImgDisabled = ko.observable(false);
 var wildPokeHealthDisabled = ko.observable(false);
 var wildPokeCatchDisabled = ko.observable(false);
-var avsDisableNotifications;
 
 function initVisualSettings() {
     // Add shortcut menu icons
@@ -49,7 +48,6 @@ function initVisualSettings() {
         ['poke-image', 'Show wild Pokémon Image'],
         ['poke-health', 'Show Pokémon Health'],
         ['poke-catch', 'Show Catch Icon'],
-        ['all-notify', 'Disable all Notifications']];
     settingsToAdd.forEach(([id, desc]) => {
         let elem = document.createElement('tr');
         elem.innerHTML = `<td class="p-2"><label class="m-0 col-md-8" for="checkbox-${id}">${desc}</label></td>` + 
@@ -62,7 +60,6 @@ function initVisualSettings() {
     document.getElementById('checkbox-poke-image').checked = !wildPokeImgDisabled();
     document.getElementById('checkbox-poke-health').checked = !wildPokeHealthDisabled();
     document.getElementById('checkbox-poke-catch').checked = !wildPokeCatchDisabled();
-    document.getElementById('checkbox-all-notify').checked = avsDisableNotifications;
 
     document.getElementById('checkbox-poke-name').addEventListener('change', event => {
         wildPokeNameDisabled(!event.target.checked);
@@ -88,13 +85,6 @@ function initVisualSettings() {
         wildPokeCatchDisabled(!event.target.checked);
         localStorage.setItem("wildPokeCatchDisabled", wildPokeCatchDisabled());
     });
-
-    document.getElementById('checkbox-all-notify').addEventListener('change', event => {
-        avsDisableNotifications = event.target.checked;
-        localStorage.setItem("avsDisableNotifications", avsDisableNotifications);
-    });
-
-    overrideNotifications();
 
     // Create travel shortcut buttons on town map
     const travelShortcutsToAdd = [
@@ -156,19 +146,6 @@ function initVisualSettings() {
     addGlobalStyle('#dungeons-shortcut-buttons > button * { z-index: 2 }');
     addGlobalStyle('.dungeons-shortcut-overlay { width: 100%; height: 100%; position: absolute; background-color: rgba(0,0,0,0.45); margin-top: -6px; margin-left: -8px; z-index: 1 !important }');
     addGlobalStyle('.dungeons-shortcut-info { position: relative; font-weight: bold }');
-
-    function overrideNotifications() {
-        Notifier.oldNotifyAVS = Notifier.notify;
-        Notifier.notify = function(...args) {
-            if (avsDisableNotifications) {
-                if (args.length && args[0].sound) {
-                    args[0].sound.play();
-                }
-            } else {
-                return Notifier.oldNotifyAVS(...args);
-            }
-        }
-    }
 
     function generateRegionGymsList() {
         const gymsBtns = document.getElementById('gyms-shortcut-buttons');
@@ -348,7 +325,6 @@ wildPokeDefeatDisabled(loadSetting('wildPokeDefeatDisabled', false));
 wildPokeImgDisabled(loadSetting('wildPokeImgDisabled', false));
 wildPokeHealthDisabled(loadSetting('wildPokeHealthDisabled', false));
 wildPokeCatchDisabled(loadSetting('wildPokeCatchDisabled', false));
-avsDisableNotifications = loadSetting('avsDisableNotifications', false);
 
 function loadSetting(key, defaultVal) {
     var val;

--- a/additionalvisualsettings.user.js
+++ b/additionalvisualsettings.user.js
@@ -27,19 +27,20 @@ class AdditionalVisualSettings {
             pokemon: ko.observable(false),
             catchIcon: ko.observable(false),
             healthbar: ko.observable(false),
+            attack: ko.observable(false),
         },
         gym: {
             header: ko.observable(false),
             timer: ko.observable(false),
             pokemon: ko.observable(false),
             healthbar: ko.observable(false),
-            
+            attack: ko.observable(false),
         },
         dungeon: {
             header: ko.observable(false),
             timer: ko.observable(false),
             images: ko.observable(false),
-            
+            attack: ko.observable(false),
         },
         battleFrontier: {
             header: ko.observable(false),
@@ -288,6 +289,7 @@ class AdditionalVisualSettings {
                 pokemon: 'div:has(> knockout[data-bind*="pokemonSpriteTemplate"])',
                 catchIcon: 'div.catchChance',
                 healthbar: 'div.progress.hitpoints',
+                attack: '.pageItemFooter knockout[data-bind*="pokemonAttackTemplate"]',
             },
             gym: {
                 container: '#battleContainer div[data-bind="if: App.game.gameState === GameConstants.GameState.gym"]',
@@ -298,6 +300,7 @@ class AdditionalVisualSettings {
                 timer: 'h2.pageItemTitle .timer',
                 pokemon: 'div:has(> knockout[data-bind*="pokemonSpriteTemplate"])',
                 healthbar: 'div.progress.hitpoints',
+                attack: '.pageItemFooter knockout[data-bind*="pokemonAttackTemplate"]',
             },
             dungeon: {
                 container: '#battleContainer div[data-bind="if: App.game.gameState === GameConstants.GameState.dungeon"]',
@@ -310,6 +313,7 @@ class AdditionalVisualSettings {
                     ['h2.pageItemTitle', 'after'],
                     ['h2.pageItemFooter', 'before']
                 ],
+                attack: '.pageItemFooter knockout[data-bind*="pokemonAttackTemplate"]',
             },
             battleFrontier: {
                 container: '#battleContainer div[data-bind="if: App.game.gameState == GameConstants.GameState.battleFrontier"]',
@@ -334,7 +338,8 @@ class AdditionalVisualSettings {
                     return;
                 }
                 const selector = selectors[state][setting];
-                const binding = `ko ifnot: AdditionalVisualSettings.graphicsDisabledSettings.${state}.${setting}() && AdditionalVisualSettings.graphicsSettingsActive`;
+                const binding = `ko ifnot: AdditionalVisualSettings.graphicsDisabledSettings.${state}.${setting}() && AdditionalVisualSettings.graphicsSettingsActive()`;
+                // Add binding for this setting
                 if (Array.isArray(selector)) {
                     // For binding multiple elements at once, which requires more complicated selecting
                     selector.forEach(([query, order], i) => {
@@ -348,6 +353,14 @@ class AdditionalVisualSettings {
                     });
                 } else {
                     const elem = container.querySelector(selector);
+                    // Special case: insert a backup attack-disabled element so formatting doesn't look weird
+                    // Do this before applying the main binding to put it outside the binding comments
+                    if (setting == 'attack') {
+                        const replacementAttack = document.createElement('span');
+                        elem.after(replacementAttack);
+                        replacementAttack.outerHTML = `<span style="display: inline;" data-bind="${binding.replace('ko ifnot:', 'if:')}">Pokémon Attack: <span>-----</span></span>`;
+                    }
+                    // Insert the binding
                     elem.before(new Comment(binding));
                     elem.after(new Comment('/ko'));
                 }

--- a/additionalvisualsettings.user.js
+++ b/additionalvisualsettings.user.js
@@ -282,6 +282,16 @@ class AdditionalVisualSettings {
 
     // Must execute before game loads and applies knockout bindings
     static addGraphicsBindings() {
+        function selectorWorkaround(element, selector) {
+            try {
+                return element.querySelector(selector);
+            } catch {
+                const [, outer, inner] = selector.match(/(.+):has\((.+)\)/);
+                const innerElem = element.querySelector(`${outer} ${inner}`);
+                return Array.from(element.querySelectorAll(outer)).find(e => e.contains(innerElem));
+            }
+        }
+
         const selectors = {
             route: {
                 container: '#routeBattleContainer',
@@ -343,7 +353,7 @@ class AdditionalVisualSettings {
                 if (Array.isArray(selector)) {
                     // For binding multiple elements at once, which requires more complicated selecting
                     selector.forEach(([query, order], i) => {
-                        const elem = container.querySelector(query);
+                        const elem = selectorWorkaround(container, query);
                         const commentBinding = i % 2 == 0 ? binding : '/ko';
                         if (order == 'before') {
                             elem.before(new Comment(commentBinding));
@@ -352,7 +362,7 @@ class AdditionalVisualSettings {
                         }
                     });
                 } else {
-                    const elem = container.querySelector(selector);
+                    const elem = selectorWorkaround(container, selector);
                     // Special case: insert a backup attack-disabled element so formatting doesn't look weird
                     // Do this before applying the main binding to put it outside the binding comments
                     if (setting == 'attack') {

--- a/additionalvisualsettings.user.js
+++ b/additionalvisualsettings.user.js
@@ -18,136 +18,146 @@
 // @run-at        document-idle
 // ==/UserScript==
 
-var wildPokeNameDisabled = ko.observable(false);
-var wildPokeDefeatDisabled = ko.observable(false);
-var wildPokeImgDisabled = ko.observable(false);
-var wildPokeHealthDisabled = ko.observable(false);
-var wildPokeCatchDisabled = ko.observable(false);
+class AdditionalVisualSettings {
+    static wildPokeNameDisabled = ko.observable(this.loadSetting('wildPokeNameDisabled', false));
+    static wildPokeDefeatDisabled = ko.observable(this.loadSetting('wildPokeDefeatDisabled', false));
+    static wildPokeImgDisabled = ko.observable(this.loadSetting('wildPokeImgDisabled', false));
+    static wildPokeHealthDisabled = ko.observable(this.loadSetting('wildPokeHealthDisabled', false));
+    static wildPokeCatchDisabled = ko.observable(this.loadSetting('wildPokeCatchDisabled', false));
 
-function initVisualSettings() {
-    // Add shortcut menu icons
-    const getMenu = document.getElementById('startMenu');
-    const shortcutsToAdd = [
-        ['quick-settings', '#settingsModal', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAMAAADW3miqAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAkZQTFRFAAAAAAAAAAAAAAAAAAAAAAAAAAAAU1tsSEhgGyM0AAAAu8Pcu8PUwMDYKSk5AAAAAAAAoqq7AAAAAAAAe3uUxMTdu8TcvcXet7fIgJGiAAAAs7vUwsLTx8fYw8PUt8jZAAAAAAAAZWV2v7/hMTlKtLS8vMTVucLavMTdAAAAAAAASEhIJycncXFxcXl5c3N7cnJyZmZmu7vUAAAAAAAAtLzNv7/QRERE////t7e3xMTEQEBAFRUVdHR8aGhwAAAAdXV1vLzNc3OEAAAACgoKs7vLAgIKdHR0dXV9BgYOtLzEAAAAAAAAAAAAe4OTOjpCVFRcKTE5xMTVAAABBgYGbW11b29vAAAAAAAArr/QtsfYpqa3MDAwAA0eAFZnAFZ4AA0vAAAAEBAQvcbWMjtLISEhAEVnAJO0CbbfAKHUAJK0AAAeb2+ACQkJv7/YSUlaNDQ0IYepAJC5AI3AISEyvb3Wa3OEXWV2HT8/DZW3AJKzCZGzAAAICSsrAAUFAHudAIytAGuNKTFCMjJLRUVWACYmAHmSACwsDAwMICAgAAAAm5u0RUVFAAojABMjvLzecnJ7YWFyKSk6Y2t7S0tLBwcHAAANh4eYAAAJanJybXV1VFRUAgoKrq6uAgIDNjpTVGVlWlpaeXl5cnt7CgoTqqqzmpqqOztbMTlKY2N4na6uKioqERERcnJ6ChMTvLzVY2N4YGF2wMDiMjIyCAgIExsbtLTEOj1FjIydOkBAs8TVL0BAWWp7YmJzkpqzc3uMdnaHAAAAI+eLBgAAAMJ0Uk5TABFE/6rdd////2b/////iFX/Qv3////////v//////+E4f////////9x3P//////////5fv/////////////Uf///zP/////////DzGo////////////u+7//////////yL/////////////////////////////////////////////////////if//////////////////////////E///////////DAP/////////gv///////////////////5k2RgJ2AAACq0lEQVR4nJXUaVfTQBQGYPBFUZNqtTRFKa3SElCBVqQQLNEARXFfqtgGt4qKYkVQEEXcxR1w38UdRcUNrIr7P3MmCdDQw+F4P83JPHPv5E4mcXH/HfGjijEAErTxWIwbiSSO1+aACcDEGEMIw7CGSZhsNBqBKSxL2DAz1ZRk5khYoEQyHU8D9HucbjKrKMVqTU212ejYnqzPNWNmmsPBWQwGp5rJmc5nZHCZejRrtoKcmIOs7ByXey6cubkEGXXl5uU5PPkoEArne4tEGguQzjuH7XyhycEDAqlUCAWJEopLUKpDeb6yRYtVVFBerrIlS6P3tGz5CthXrlKRoGUSxdVr1voHUpWaTGTOtk4S10MQBK+3osKtIBd4v3+DigIIynKwcqMkutw+YNPmLVtVJGYFS2g/QvRAtskcV7U9J4c+37Gzetfumj1hOg5Le2tZfp+yMdQRxMDlohOor95/oKa+QSQZCGpkec9BBTWxFKkVDh2ubm5uPtIikhcIh8FwHNsUg45qSO3ZCOjYcYJOnGwRaChIrlPQKQ/PNp6ukCg603qWBM7RTOcvoGoAXQT8ibWXLiuoobWtrb3d7ZYI8vq8tDlq20PjSPUOEOQmA1ESr9DXRF3YZwtevTb03Seg4/oNUSS9vKkh0hCvz04WBQZvROjW7cw7dDmyB05OvIsyt9LtqHvAMLgH3B9CDx7y6HwUjUJ4LCfjyVO17+Rrevb8hacLL191RyEjXstW65u3PT3a2b57zzm6PnR+7NaVqyWN+yT39uFzUVFfL2OwcI5IEr7oqn1Vkd1eXJyfn2KhV8ocieCbfuP9/eR5pgfffzT91JB52B2OB9LI81/qtUPEwDJMJfQdiKP/Efz+oy0FDGwXYg3dlx+BwbwkjDFEmRu8ZvGBv7FZRol/3T2xhRzFta4AAAAASUVORK5CYII='],
-        ['quick-inventory', '#showItemsModal', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADgAAAA4BAMAAABaqCYtAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAACdQTFRFAAAA0KhgoHhA+PCw+OB46MhgQEhoqKioeHh4WFhYuEgA2GgAgCgAQaYPaAAAAA10Uk5TAP///////////////y0EQa0AAAH3SURBVHictdTNkpNAEABg5IBXe7bgnGGJOSuU3kmT8koq4xnWdZKjFasSHsBKyBuQV/AR9OKj2TP8zMCa1YtdRULPR1MzTIPj/D1ewKsbieO4d/Fbk93Hb2aOncbJkLvL2L7UjacYm9L5J8K0zyLCd+sBcxYnaBCXMfeH+0CAiFnRZt6GkhJmA0KEKLrUFYgpDOgBPKKAoM1KELgCKAyynIUh6AhD7vMRBms1xzaSdF6OK40pHVcyjK3Af0W9lBFaS3kWHf4UmWOjPdsnqErfH49fVeEIS4WoTCkqDCx8pBGsFdbqbGVjsKeRD7WOb3S6KA16wWGM27IwyI50X4LuZ3XkBt1wt9+gLqJyzBancHgG7l3y+rzf9Jgtqofl0Ln3ccJ354PsYlud2LLvXFdtA9vV9VVHXZ+42qTZgBEwOQSH1CDNPULVPG0AYEpDBmklmS905NS3Bj1kcorff/74pXErL9fbWNUyuoWefICbSC30DNJLNEVhLeV/4ZyOHgnWwjwhQhodUAiFhUHfxtzGTPA819W6yveZ2PRIl3LwgbfIIAdGd+la7DMAvefA228CoyMA+Nh3Ju3+GGnA9CZtm43y4NixraQV5ynWzbWLSz3Bl9Xl0mPTnL+M0NOVTaMuocpihI6k4Ua9ZPTXSGcSnplPMbU/xm/a6CAG6AGINQAAAABJRU5ErkJggg=='],
-        ['quick-pokedex', '#pokedexModal', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAWz3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjarZtpduQ6doT/cxVeAjEDy8F4jnfg5fsLgJkaq/zc3VJJmUqSGO4QNwJAXfN//ntd/8VXzMZfPqQcS4w3X774Yitv8n2+6v5tbr9/n6/+vJqvn1/vC5aPHK/u/Jnjc//rc/Nu4LxU3oVPDeWnIdO+Xij+aT9/a+jpyGlEljfjaag8DTl7LpingXqmdceS0+cptHlen+ePGbKmxq8y9q23Kc9ovv3tE9YbgX6ctdMZd/PbOnsG4PRjL1d5E/htXOBG87xP/ObrGQkG+c1O96dRXT+88npn/vD5N6e4eD6/+OCrMeP79dfPTfjd+Nc28aeeXX/3/OXz0F4W+2pk/aw18rXWPLOrPmLS+EzqNZX9jhsbJnf7sch34ifwPu3vwne+iN6OyweB2fjuphiLW5bxZphqlpn7tZvOEL2dNvFqbbduf5ZdssV2d194yOvbLJtcccNlnNlxr+NT+x6L2f2W3V03mY6H4U5raMwc99v/zPcfG1pLIW/Mnd+2YlxWQcgw5Dn95i4cYtYrjsI28Ov7+5f86vBg2GbOTLDe7TTRgnliS3HktqMdNwZeT66ZNJ4GMBF9BwZjHB64I8FvormTtckY7JjxT6WhbJ23DReYEOxglNY7F3FOtuqbZ5LZ99pgz8dgFo4ILpJIGQdVfCVgI36Sz8RQDS74EEIMKeRQQo0u+hhijCkK/GpyyaeQYkopp5JqdtnnkGNOOV+55FpscYBjKLGkkksptdJppeXK05Ubam22ueZbaLGllltptRM+3ffQY089X730OuxwA5wYcaSRRxl1mkkoTT/DjDPNPMusi1BbbvkVVlxp5VVWfXvNXMetP77/udfMy2t2e0o3prfXeDSlVxNGcBLkMzxmvcHjSR4goK18dlNDvL3kOvnsLpasCJZRBjlnGHkMD/ppbFjm7bsPz33x2+X9v+U3+/LcJdf9Jzx3yXV/8NxPv/3itVF30XTX9pDSUEa9HenHTdVm/lGT/v7q+ljTBRyYy9ViWovU8TRukqWAU8RbWz3i4WJc7IvGJ7BWFh1MX9edqwqnWvt4vb5/YNugm7smddNSUTNKUb3SkxnvnozXZ+qLCc+LrpY+oDNHO8vnfzivb69Edp2+9QA600pZt5xsRg6A7JgdPAbZSyaICKw5bMiJcOyr19jq0DxXHoyXhqzD6aooALbGtqvJbXQV7G7rHvq0L3poepdm3fdNwiW9b7nW645znathglfwEhninzd1cc+fm6qe1Iwr51F9yjV1N+Ii2p2CzfRmxrCdgJzgkUkgfE8xOubdbes9zXGXmYcPnYhqZoVaB+9DbeSda9bNvHi+Uf1y7m41X0u65O1gOxFqHJUw87FNJGSI1Ta7ah/ejXtNUsGSYyuV+O4pPQ9V0OTirxgrcRKNuqN9ulox++Vjdc8jIZBsbjYXiP1249pR1pj46OnWrOt5pDITJlFqNviPoJt9zfUx0jZcm/K6j0OVeICh5K1pkwyexYar2FmqiAHg1ECF7Fq7yVIAZQagKW6PDTqvIzbPv5kY+LaoLOUmQLvmuGwZc6Uw/Eo7q3IYaRrl2bIjJIaFLfAsaLbW+yKp8eUyucYdrVuiHHPOROqnf62567T3bo5sq2QMpf9kjImzgglgYFDGJNvhQwI+oNjiiuCfyCFp3yljSRTly0w7X9TBEgqHORclIRCk5tfX0Imj7h2kKsyVffPUbyLGWuDDBrmBsmETxaARdK3M7pNbjHsJzR4DWL8NcA3btgXKscDtxphMzT3IN8MGPoYm4KN5mMzdKmGwkcrNULHRWPUqO/14IJky7cAozIm0CoGO+TYtcjHPW/UL2LtDv7HK6IUYiZQkR+wx4suRidFUaglh6mpqpagiRWLWAa3QEzjC8qGSg835vvyObWhPSYptEsm72Q1Ju4SnUB+Kh8VEws2Il8kyd3KMqhG4qTDoNWlwgBXUNlctCo0MCLkNkpYKVTCoD7m37BBJN6T0dryfVLDtO6DRnTApq7S5VpvCwFz4vJLyjqi+hpmT2tUIF8ZUQhh9OXC46daJZ2PemO6WS7RKwtMipK3PSWCZCCbZuYoVYwstU5bJMhzeK7lkiTLcB4/D5dkrVplCphTlStqD5BlDwaexNgCZ9cn15aNSWhGiqZhF3wGChVcdpsGEPz65zb6XOoFZrhAHTkVTESOgIfV25tgAQSzTKFky79rmZYghesg6mO1CJaoqaIOxadj1y3koCw6Oifxv+HtASjEmDsttYyCBGFtzx/mlfXZkjLluzGikSFsDDOlZEbNKWq3iGuCTv5CGPFZJjP3YZMR3IDq8UhzfUWgYccZ6Da/hMOL+hvCA76Boj7COMUfxLjbrM8xLxKcEgN5EJojI3Qk3d2hMkwKB4K41UycjaZ+A2LFixHEcrDoQENRJsBYTTl/mpNQxc4rVjq5Xyu2Eu3bGKeGUbiQgBnjQoCUP8hPqEzTY+QYoi1WGeIMGthKBXpbGDs4gjsdfWM8/Jz3XN9aDm1UWCRgAiOpGEuB8YDMkh+hbOaZKC9tT4CG4FwRvIV2ly8XDP3hn8DuFBM9YiJ7qR7o30FRjR4pUXP/79et1g13J4emNfMIdUMVkTS/M/UCd5wFvI/6qP65fn28A6VWYwf0pHovJKgT1ZTubY8XjZlZhKglGkaNyRqAYV10rMIiEXawLpM4PbDd+7iYJWgczjmRZGwpicgdMgzAT6Wvj0cILJ/mSIjLfq+QOzQIk8MNdVepOhbFx7ArjzakwoigElaqMGNuJej/ayZo7HxKVG5FPyYJ+2++MFWw6hI+PaF1876L5YyOK07t5Q6Tvtp0yKmM22i2nhmL3QXd6JkDlqPcLoVOwkdQmE6YGwwImFQF/AE7ODUQBfU2yxFGZZTOK564GsJP9550yI6KIwyGJiESXI+lpCEft0Nyloq2BG7QP5sXZMzb0BWlEdANrZaoqUQtXuQMNXFO0oNzE5R4skLEckYJ+KSrB4u1+npCc1oFHwWTcb0DnsZsxuci9V0ALpTZTObFNYW19Oz5oiQcWilsJ/h10VJaFbBqldkKY5twEwAb51Ps1ZLNvaQvonvHlNAtciwTcJKYSMTsFEUuYlLzrGI1ZA4KUo/tDWryExdYVYjjSFUrnv8fSuFO5RKZfQTzjvrgRy6UXSZAoW/VUtzzDB6jplueGW4Rd9/C4gC0/DcrO8EzrYkG3I1AWNTfz3cLyIlvJN2ccRVucQjhKXRPGkQeUqhfV/VLiDS/DieVCBxzUeRNQK1owbAVJUxq0+qbHJIIrKITWjIGWkP0LXhdppmt8ynlFcVHYUX6RAcnhhtSIg60BEMdi3TVRWRACJ9Pp3N9zKFyc2Rwg5aE0XnZ7r4fHUgWpe5hBv+IUupQNaNMKsKpFdhmAO/gKsBYSgIrYYIERLQ7bgmbQqU0wDpH6HWHhCvB8EiJQsvBBF0afdklcM1TvNgqGByXTAcGwUdKDAGXATJpxkutxgg8dFYFIjx+tasAf7WqdlT96gH4OEIHxZnRlVFD5zNTsjoJETR+V8f4Vq20gkPGq7dkR9jfljAzCVdx/WSicOP0ybTdJAT/cH7z+i7HBCkA1wcIl6DDmdRKU2PIfgt20sGOcyNmTSpjGudDc70msWkX2nzx/8t2VCC+G9aCWmHgC+lcjNZcGxHRDJJImSThARbCNwGV+iErcL1vHrDCGMo1Ogfz8JGVpJ1WG6Tjy3XXXEr5ITbJWZIWiaDHZBdn0Efy44V4OZuRHwiOUFKKiZmaoSMXkuWo1SCFWKGiu3c7TvZliyGnc0Jpfc/lzKr9Ewx/xYOc6AQntzi8b+S+kPIpsAYKW1nrT4jjKklBfzcIr5urMQP2R8u0S5EsDUGmZBsSodjgboaka5ASoA3zAWnDJ4nBfUmkArLF8ge0DKJFotpeJFuSnfkDBU7v98F/9mOjlnpv13wjwtQCgU0Ap4OBTQhEXeOflR4XsN79u22PvdH1rIyR3mLD0WQ1xW60rcpWWRG6QiBCME7UF8URa+kvL4VBitW0QaebVd9h9q8T6sRdAvrSzM6A9GdDvAfiH1tApDeUXlYbuztTGXm/aLE4MEko6S6/BEnZ3xBOwDuK73VBGkBFue/hRgkJYtM+gC4K2JtEerYkEj/lbcjcDpnYRWSac9a1PbNyddmjkOq0QG1rVmNE4SlPLQ/oIrw8fYYmkfpVExspSH+DEWWlKVv7cExwXFDzz3eAMN1rSRtHzJPAld79m6ZOjjBPEZvQ+PbQUfjyuZLRq4CxQeFdka9ZiEs615nv5tZ/y1fUHFQjcW/yegOxCXvciPZ8pzy+MhxZB1FRQRowQK0CO6+7pgsMT5+9ux07WpWRV0tI88uehVRh27tDE7FVUKYp4Z3Qns4QfQcZ4/HCRHd3mW3B/kJOyduISLenQ0Xjo6NocEkK2DiEd4K9YRgZJKIL42GnsYQ8XjkbAvmlk3pogAKKD2G/u+lKfyxA1s7C79MiEagGnMyRSYPYf7PmsjyYCctt9978FOnW6mJHnqS4mf8Y4LSkK5fr66Rr4EemNJj3UmonjhId4osx7/7k48wM9d7vXD6Lbl6YH2WyKOMgYxiG0tmmW06rg28X1LA1VSK2MrWbNM9x9IdzttOoUS7/QvMPyCiwvb5b3MP8pEPwkCeDtWOyOWw/Inaq3a31aiAap+IcIf7CP+DHXsT12tkM0GW/vqY4uKMJa8Fc09l+uKr7gFNdLIIZC5ikWEOHjD+zfnoDqUwudNe0BxQrYhtouOfGJ/RP5Zf2UUg1wBC4pC1Hmu7eVtmcbDHZnxfU5uBoWQud3aWwt5xTBeAyPxoZ88q8ZSWxzq0SeZeKzNH1BxyCuVgtu41CDqcUXbQ1pXWGbPN0vk7/W/olZ3DZk6M2oCgrSGEH6lBhYWpGBxFjxzQEHpjueDcvCHWr25YZ3eqmPDjdhvIwNSjU60hWipUVbyXUiccMV4JsFgZCALdR64Z6EPNTWDwHVfcdKblGHQURssEnH9bAOrbCgeg7ZKjvs4UmqAW4vZ4/OzYwtaRP4fSs3Cv61TncRGFau2qvQseKx0UpukwyZCpTRqx/kbrg7IrVMrVjL6wNhmVWitDQ9bbzOuqGvpYkMDW0FLGNDmVkJ11Tec64JltfAWIxPTYkUiVvgX4OWUBWw5rInYtsTsWtDc4AyCe52qYblyzNwG60ZTeaxXgSTsuREMMnCizzb+4DwSzL0c1T9/9Lm+pE3xjfF3W3hUGVMwv8vTrMN6KcQh4g6ag4cAXnLn/x0CvWtQi1qRYmc3ahQa/3PkVbAegLYsuGWKOmLRzE5UOEJN7KtkxtOfA7FRMXPmvukwoUd6FmCYO/gxAYbwXywfq1KqksiSurhiI4tObokR1ctQegAV+S+KiFlq/SoLSF7CP4FJa4SVKsK3eF9sCF4TPO9aY8SDqGfMbWAhN+tT4lRgZsNo2r9bCs4I68lbdtX4xBhuWT3URXTSVVS0u99KGXk3mNace8xpU3AnouX5niu3/e5Q7tUCffT4QZl7eopTAEpFP6zcSaWww8xDB7B2WmIqldcGECeL9oJ5cebGHtJsN3KQ+jfokWu0mdE4yiZ6yGkmZLzQJDW/A8GnVX/IIgBaAQzXSt+GsxwezAMdu/h7R219MCPtnX3htq18Wc2wAe/RwggCSJS2SoP49ZEbhGFI9jus5eEul223iFLChxYtSwpD67pmt9F6piVKJiPWcvbrPbszzidITnr7GNo9QooPdszeOcSWGpdaKazKL/1D6oEvBG4rfFokrzT1BOjECduTsFrWbYd8xvq2k0/5RnUe0iPL8sXX+6BycTP0L4M7BLIbww/sGIPQm5c2agisYDZ5ll5+/OILwiTFc+HzKwM0EcqMeyS3+P2KKJWqGXVgZqOoEAMaPsnwusRgLCFOxYRPeVaf60WofrjThYSdJltEoT5vlKmOxt2qTet9/EGnYDo0OWiSyeyDW4+MmVvXqB74jahxHXb4lrryViz7l2hZ/JhT/4FZhdgx3MlJfQfcsRpOc5Eh8pM6NtoAEqlfaI7rVy/AGTrmygHNVXEbq9MfEmetG1mQk7rX4BE6EeS+nb2MoQXcfNK4GKKgR0pr9N3TDxfII5uNVbUTfX1qAxlTn7WZL4MQAJrD+HzCOj/+jSAn91/6Zyu6fNP8He1UpACXuo+QDRGs1ZyHkQNxjgDSUWSt7iVfAjuj65QZA9teLW3P+pP9fh7gMzpOs/dY7jWL4iu90Tp1Pri8BBl50qLIaDWQwi2auOGbNfJookB4KhaPraqOePZGUGT5Uu7Q0rB8DkF28lQrscziXMDht630BC3fD734Pr1r2xdfNu5gCCted19n8d4doy1aPY+agFlqjCglY/2tjZpLtCgvWPU8tQeqolH5Vz3z/MeWAlRsTdXDVQNsrrHQClSu3+gZNfDyTTNWb+1SVH9FDbfFuuonHl8XL9+ueEvZ2BIf60b2LtqUbs1cfA7qMmdIn+6+OvBlnOs5cehluv3peffjrT8fXPq+qcuJjePPWx97HXKBcIMURrb9bcbZO7XcJ7Ns1/O+ZzXS1Ga/ul5o8fWOib2YVAdjQ1kPzZ92fu3G/5k8++Hia7fTxP9n4eJXLGS9XDcpq39mS/0EoRKGPP5rEzvJmlXCr1ttK9PKZY77hrc68gAhW0fGRjnxMClRVjtde6Ke6D1dffXe7kxGB1zKTro6m7UoVYmC8KvJJ0bqQh/akjWgtRUkarJFe9G485JKr2PKv3xpNIe0sWTz9LZLi2M4F3bNprnsdFcJyecqPge+o4QyWzXXouc1y7gr1XOA2hCjk05egv+wFl44Gyr8HPKiSKPmQNKdfiJFqkmx+G0aRTgrh7lklEu9t5HhJ4lsOyhxDvmC92IN3V7Gg5qeFOP68D994XKss9D3SI6XzSNqpr5snD+0jXXPrey7vfK+VE25kVjyojluLvrfN7UntzZr8hfx3r9Mtg0/rAMVWqeTX6F3lhw1PrOV9E+mk6M90g95GkdwRLomV05BHt2V1OxWRuVwf4P3lTtu6y2TrQjEndxPjsiYgUiB5sWaPfiGNqJGKRez8qjOdzoCZ7rI3qUnsqiRqnc8ZvgMUSlZybQbhJmkkCwoBQrNE3ha0SQXCGT2kVcr0dSGPusAIT3CoD0xrOFx0CUzWYeHHXWaftOGX0rgK9gyz75c9jzPvqzFyKwUpw7TcwWrXIHUOcB2ARtaPsUYPJDJ46d09JYRYmndD8bB0Tqbx57e06JfbaDkz3bwanuinZpSWLgVKu91A7AW6FgLbA95pfAG8ELhEmHGBBNWmGJTgc79iEGMdWGZ9b1OtzFDM/hrnFOb211wOy2eHguPuIhfRIPUXVbO9NXXf+RpsrVsOHZbA4UEyLSHLQukQpUiVr0wKFSsGOvJV68KiY1tPGeGyS+ER/xCreWxZq9bcUwU4ZfVCpzKNRm7CcYRct/4+v3YewqRw9jfzYENq4pHc9n6wdrH49o+EoJr39dNHzVDNf/IRre3UsW7gFsSPngpFqo1wiuv1jhq7B/dL125VwwP8Z1vcSMiuvNg2TXRHbMYhDcsF2yNHDvjcRmdHGEEoKv2rJDe/e6c9ZRsa7NV2rM/248XR+x+e81db1is9xnQ/+UwfcBxI91h6UzhiA2aBCLk389RYesbbmNYq9Q9L86IA+tainco+16PcpDUPC304tfXq8fi/gz/vXcyOY3vxDA68Xx/wJCH2C00fH3ky/XOfry6uovVOr+dOjhl/ldX+fFGAut/y++qc+OAKk1OgAAAYRpQ0NQSUNDIHByb2ZpbGUAAHicfZE9SMNAHMVfU0tFWjrYQcQhQ3VqQVTEUapYBAulrdCqg8mlX9DEkKS4OAquBQc/FqsOLs66OrgKguAHiKOTk6KLlPi/pNAixoPjfry797h7BwitOlPNvnFA1Swjm0qKheKKGHxFABGEEUJcYqaezi3k4Tm+7uHj612CZ3mf+3OElZLJAJ9IPMt0wyJeJ57etHTO+8RRVpUU4nPiuEEXJH7kuuzyG+eKwwLPjBr57BxxlFis9LDcw6xqqMRTxDFF1ShfKLiscN7irNYbrHNP/sJQSVvOcZ3mCFJYRBoZiJDRQA11WEjQqpFiIkv7SQ//sOPPkEsmVw2MHPPYgArJ8YP/we9uzfLkhJsUSgKBF9v+GAWCu0C7advfx7bdPgH8z8CV1vVvtICZT9KbXS12BES2gYvrribvAZc7wNCTLhmSI/lpCuUy8H5G31QEBm+BgVW3t84+Th+APHW1dAMcHAJjFcpe83h3f29v/57p9PcDbYFypYJjNYkAAA+caVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA0LjQuMC1FeGl2MiI+CiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICB4bWxuczppcHRjRXh0PSJodHRwOi8vaXB0Yy5vcmcvc3RkL0lwdGM0eG1wRXh0LzIwMDgtMDItMjkvIgogICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICB4bWxuczpzdEV2dD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlRXZlbnQjIgogICAgeG1sbnM6cGx1cz0iaHR0cDovL25zLnVzZXBsdXMub3JnL2xkZi94bXAvMS4wLyIKICAgIHhtbG5zOkdJTVA9Imh0dHA6Ly93d3cuZ2ltcC5vcmcveG1wLyIKICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIgogICAgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIgogICB4bXBNTTpEb2N1bWVudElEPSJnaW1wOmRvY2lkOmdpbXA6NzMwODk4ZTQtNmFlNy00OTg4LTkxY2QtMWZjNzljOWM2YWMyIgogICB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjdlN2U2MmY1LTIyNWMtNGU0YS04NjlhLTJmYjRlYzg1ODUyZSIKICAgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOjk0YzQwZGZmLTBkODctNDc1Ny1iZDNlLWZhZjQ5ZDg5MTU3ZSIKICAgR0lNUDpBUEk9IjIuMCIKICAgR0lNUDpQbGF0Zm9ybT0iV2luZG93cyIKICAgR0lNUDpUaW1lU3RhbXA9IjE2NTI2MjA2NTQ2Mzk5MjQiCiAgIEdJTVA6VmVyc2lvbj0iMi4xMC4yMiIKICAgZGM6Rm9ybWF0PSJpbWFnZS9wbmciCiAgIHRpZmY6T3JpZW50YXRpb249IjEiCiAgIHhtcDpDcmVhdG9yVG9vbD0iR0lNUCAyLjEwIj4KICAgPGlwdGNFeHQ6TG9jYXRpb25DcmVhdGVkPgogICAgPHJkZjpCYWcvPgogICA8L2lwdGNFeHQ6TG9jYXRpb25DcmVhdGVkPgogICA8aXB0Y0V4dDpMb2NhdGlvblNob3duPgogICAgPHJkZjpCYWcvPgogICA8L2lwdGNFeHQ6TG9jYXRpb25TaG93bj4KICAgPGlwdGNFeHQ6QXJ0d29ya09yT2JqZWN0PgogICAgPHJkZjpCYWcvPgogICA8L2lwdGNFeHQ6QXJ0d29ya09yT2JqZWN0PgogICA8aXB0Y0V4dDpSZWdpc3RyeUlkPgogICAgPHJkZjpCYWcvPgogICA8L2lwdGNFeHQ6UmVnaXN0cnlJZD4KICAgPHhtcE1NOkhpc3Rvcnk+CiAgICA8cmRmOlNlcT4KICAgICA8cmRmOmxpCiAgICAgIHN0RXZ0OmFjdGlvbj0ic2F2ZWQiCiAgICAgIHN0RXZ0OmNoYW5nZWQ9Ii8iCiAgICAgIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6MGIzZjhkNTAtNjQ2My00NjJlLTkzZGEtOTM0OWNhOTE1YWFkIgogICAgICBzdEV2dDpzb2Z0d2FyZUFnZW50PSJHaW1wIDIuMTAgKFdpbmRvd3MpIgogICAgICBzdEV2dDp3aGVuPSIyMDIyLTA1LTE1VDE1OjE3OjM0Ii8+CiAgICA8L3JkZjpTZXE+CiAgIDwveG1wTU06SGlzdG9yeT4KICAgPHBsdXM6SW1hZ2VTdXBwbGllcj4KICAgIDxyZGY6U2VxLz4KICAgPC9wbHVzOkltYWdlU3VwcGxpZXI+CiAgIDxwbHVzOkltYWdlQ3JlYXRvcj4KICAgIDxyZGY6U2VxLz4KICAgPC9wbHVzOkltYWdlQ3JlYXRvcj4KICAgPHBsdXM6Q29weXJpZ2h0T3duZXI+CiAgICA8cmRmOlNlcS8+CiAgIDwvcGx1czpDb3B5cmlnaHRPd25lcj4KICAgPHBsdXM6TGljZW5zb3I+CiAgICA8cmRmOlNlcS8+CiAgIDwvcGx1czpMaWNlbnNvcj4KICA8L3JkZjpEZXNjcmlwdGlvbj4KIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAKPD94cGFja2V0IGVuZD0idyI/Pn9Za1QAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAAHdElNRQfmBQ8NESISKzy+AAAA3ElEQVQoz5WSIXrDMAyFf3cBA4MBPYKPIRjoIwwWFg7mCIU+QqCgoeBgYGDhQA4wpoLGWZaFTMRP+t57ki0HdiEivs3NLGzzZk+8mO0d/I9QRHwAH2P07/zhY4w+xugD+ADeg1fDUxXFGInXBO/981xqAHHT8EVE/GJG27bMnxPt6xfTTVfCPM8AvN3vINI3WyeA6aZcz2cO71NHqoSKSymklMgiTxPAFtwAlFLoum4V5Zx/8EJMKaGqhPpKpZSVVMUppbWmqphZOB251pGOIuwXtyeq6q+Nh/9+jQcRyGEasqbeQgAAAABJRU5ErkJggg=='],
-    ];
-    shortcutsToAdd.forEach(([id, modal, source]) => {
-        const quickElem = document.createElement('img');
-        quickElem.id = id;
-        quickElem.src = source;
-        quickElem.setAttribute('href', modal);
-        quickElem.setAttribute('data-toggle', 'modal');
-        getMenu.prepend(quickElem);
-    });
-
-    // Add AVS settings options to scripts tab
-    const settingsBody = createScriptSettingsContainer('Additional Visual Settings');
-    let settingsToAdd = [['poke-name', 'Show wild Pokémon Name'],
-        ['poke-defeat', 'Show wild Pokémon Defeated'],
-        ['poke-image', 'Show wild Pokémon Image'],
-        ['poke-health', 'Show Pokémon Health'],
-        ['poke-catch', 'Show Catch Icon'],
-    settingsToAdd.forEach(([id, desc]) => {
-        let elem = document.createElement('tr');
-        elem.innerHTML = `<td class="p-2"><label class="m-0 col-md-8" for="checkbox-${id}">${desc}</label></td>` + 
-            `<td class="p-2 col-md-4"><input id="checkbox-${id}" type="checkbox"></td>`;
-        settingsBody.appendChild(elem);
-    });
-
-    document.getElementById('checkbox-poke-name').checked = !wildPokeNameDisabled();
-    document.getElementById('checkbox-poke-defeat').checked = !wildPokeDefeatDisabled();
-    document.getElementById('checkbox-poke-image').checked = !wildPokeImgDisabled();
-    document.getElementById('checkbox-poke-health').checked = !wildPokeHealthDisabled();
-    document.getElementById('checkbox-poke-catch').checked = !wildPokeCatchDisabled();
-
-    document.getElementById('checkbox-poke-name').addEventListener('change', event => {
-        wildPokeNameDisabled(!event.target.checked);
-        localStorage.setItem("wildPokeNameDisabled", wildPokeNameDisabled());
-    });
-
-    document.getElementById('checkbox-poke-defeat').addEventListener('change', event => {
-        wildPokeDefeatDisabled(!event.target.checked);
-        localStorage.setItem("wildPokeDefeatDisabled", wildPokeDefeatDisabled());
-    });
-
-    document.getElementById('checkbox-poke-image').addEventListener('change', event => {
-        wildPokeImgDisabled(!event.target.checked);
-        localStorage.setItem("wildPokeImgDisabled", wildPokeImgDisabled());
-    });
-
-    document.getElementById('checkbox-poke-health').addEventListener('change', event => {
-        wildPokeHealthDisabled(!event.target.checked);
-        localStorage.setItem("wildPokeHealthDisabled", wildPokeHealthDisabled());
-    });
-
-    document.getElementById('checkbox-poke-catch').addEventListener('change', event => {
-        wildPokeCatchDisabled(!event.target.checked);
-        localStorage.setItem("wildPokeCatchDisabled", wildPokeCatchDisabled());
-    });
-
-    // Create travel shortcut buttons on town map
-    const travelShortcutsToAdd = [
-        ['dock-button', 'Dock', {left: 32, top: 0}, MapHelper.openShipModal],
-        ['gyms-button', 'Gyms', {left: 75, top: -8}, () => { generateRegionGymsList(); $('#gymsShortcutModal').modal('show'); }],
-        ['dungeons-button', 'Dungeons', {left: 121, top: -8}, () => { generateRegionDungeonssList(); $('#dungeonsShortcutModal').modal('show'); }],
-    ];
-
-    travelShortcutsToAdd.forEach(([id, name, pos, func]) => {
-        const button = document.createElement('button');
-        button.id = id;
-        button.textContent = name;
-        button.className = 'btn btn-block btn-success';
-        button.style = `position: absolute; left: ${pos.left}px; top: ${pos.top}px; width: auto; height: 41px; font-size: 11px;`;
-        button.addEventListener('click', func);
-        document.getElementById('townMap').appendChild(button);
-    });
-
-    // Prevent ship modal sequence-breaking
-    document.getElementById('dock-button').setAttribute('data-bind', 'enabled: TownList[GameConstants.DockTowns[player.region]].isUnlocked()');
-    ko.applyBindings(App.game, document.getElementById('dock-button'));
-
-    // Create gym and dungeon shortcut modals
-    const modalNames = ['gyms', 'dungeons'];
-    const fragment = new DocumentFragment();
-    for (const name of modalNames) {
-        const customModal = document.createElement('div');
-        customModal.setAttribute('class', 'modal noselect fade');
-        customModal.setAttribute('tabindex', '-1');
-        customModal.setAttribute('role', 'dialogue');
-        customModal.setAttribute('id', `${name}ShortcutModal`);
-        customModal.setAttribute('aria-labelledby', `${name}ShortcutModalLabel`);
-        customModal.innerHTML = `<div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-sm" role="document">
-            <div class="modal-content">
-                <div class="modal-header" style="justify-content: space-around;">
-                    <h5 id="${name}-shortcut-modal-title" class="modal-title"></h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">×</span>
-                    </button>
-                </div>
-                <div class="modal-body bg-ocean">
-                    <div id="${name}-shortcut-buttons"></div>
-                </div>
-            </div>
-        </div>`;
-        fragment.appendChild(customModal);
+    static initOnLoad() {
+        this.addGraphicsBindings();
+        this.addOptimizeVitamins();
     }
-    document.getElementById('ShipModal').after(fragment);
 
-    addGlobalStyle('.pageItemTitle { height:38px }');
-    addGlobalStyle('#quick-settings, #quick-inventory, #quick-pokedex { height: 36px; background-color: #eee; border: 4px solid #eee; cursor: pointer; image-rendering: pixelated; }');
-    addGlobalStyle('#quick-pokedex { padding: 2px; }')
-    addGlobalStyle(':is(#quick-settings, #quick-inventory, #quick-pokedex):hover { background-color:#ddd; border: 4px solid #ddd; }');
-    addGlobalStyle('#shortcutsContainer { display: block !important; }');
-    addGlobalStyle('.gyms-shortcut-leaders { display: flex; pointer-events: none; position: absolute; height: 36px; top: 0; left: 0; image-rendering: pixelated; }');
-    addGlobalStyle('.gyms-shortcut-badges { position: absolute; height: 36px; display: flex; top: 0; right: 0; }');
-    addGlobalStyle('.dungeons-shortcut-costs { position: relative; margin-right: 12px; filter: none !important }');
-    addGlobalStyle('#dungeons-shortcut-buttons > button:hover { -webkit-animation: bounceBackground 60s linear infinite alternate; animation: bounceBackground 60s linear infinite alternate; }');
-    addGlobalStyle('#dungeons-shortcut-buttons > button * { z-index: 2 }');
-    addGlobalStyle('.dungeons-shortcut-overlay { width: 100%; height: 100%; position: absolute; background-color: rgba(0,0,0,0.45); margin-top: -6px; margin-left: -8px; z-index: 1 !important }');
-    addGlobalStyle('.dungeons-shortcut-info { position: relative; font-weight: bold }');
+    static initVisualSettings() {
+        // Add shortcut menu icons
+        const getMenu = document.getElementById('startMenu');
+        const shortcutsToAdd = [
+            ['quick-settings', '#settingsModal', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAMAAADW3miqAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAkZQTFRFAAAAAAAAAAAAAAAAAAAAAAAAAAAAU1tsSEhgGyM0AAAAu8Pcu8PUwMDYKSk5AAAAAAAAoqq7AAAAAAAAe3uUxMTdu8TcvcXet7fIgJGiAAAAs7vUwsLTx8fYw8PUt8jZAAAAAAAAZWV2v7/hMTlKtLS8vMTVucLavMTdAAAAAAAASEhIJycncXFxcXl5c3N7cnJyZmZmu7vUAAAAAAAAtLzNv7/QRERE////t7e3xMTEQEBAFRUVdHR8aGhwAAAAdXV1vLzNc3OEAAAACgoKs7vLAgIKdHR0dXV9BgYOtLzEAAAAAAAAAAAAe4OTOjpCVFRcKTE5xMTVAAABBgYGbW11b29vAAAAAAAArr/QtsfYpqa3MDAwAA0eAFZnAFZ4AA0vAAAAEBAQvcbWMjtLISEhAEVnAJO0CbbfAKHUAJK0AAAeb2+ACQkJv7/YSUlaNDQ0IYepAJC5AI3AISEyvb3Wa3OEXWV2HT8/DZW3AJKzCZGzAAAICSsrAAUFAHudAIytAGuNKTFCMjJLRUVWACYmAHmSACwsDAwMICAgAAAAm5u0RUVFAAojABMjvLzecnJ7YWFyKSk6Y2t7S0tLBwcHAAANh4eYAAAJanJybXV1VFRUAgoKrq6uAgIDNjpTVGVlWlpaeXl5cnt7CgoTqqqzmpqqOztbMTlKY2N4na6uKioqERERcnJ6ChMTvLzVY2N4YGF2wMDiMjIyCAgIExsbtLTEOj1FjIydOkBAs8TVL0BAWWp7YmJzkpqzc3uMdnaHAAAAI+eLBgAAAMJ0Uk5TABFE/6rdd////2b/////iFX/Qv3////////v//////+E4f////////9x3P//////////5fv/////////////Uf///zP/////////DzGo////////////u+7//////////yL/////////////////////////////////////////////////////if//////////////////////////E///////////DAP/////////gv///////////////////5k2RgJ2AAACq0lEQVR4nJXUaVfTQBQGYPBFUZNqtTRFKa3SElCBVqQQLNEARXFfqtgGt4qKYkVQEEXcxR1w38UdRcUNrIr7P3MmCdDQw+F4P83JPHPv5E4mcXH/HfGjijEAErTxWIwbiSSO1+aACcDEGEMIw7CGSZhsNBqBKSxL2DAz1ZRk5khYoEQyHU8D9HucbjKrKMVqTU212ejYnqzPNWNmmsPBWQwGp5rJmc5nZHCZejRrtoKcmIOs7ByXey6cubkEGXXl5uU5PPkoEArne4tEGguQzjuH7XyhycEDAqlUCAWJEopLUKpDeb6yRYtVVFBerrIlS6P3tGz5CthXrlKRoGUSxdVr1voHUpWaTGTOtk4S10MQBK+3osKtIBd4v3+DigIIynKwcqMkutw+YNPmLVtVJGYFS2g/QvRAtskcV7U9J4c+37Gzetfumj1hOg5Le2tZfp+yMdQRxMDlohOor95/oKa+QSQZCGpkec9BBTWxFKkVDh2ubm5uPtIikhcIh8FwHNsUg45qSO3ZCOjYcYJOnGwRaChIrlPQKQ/PNp6ukCg603qWBM7RTOcvoGoAXQT8ibWXLiuoobWtrb3d7ZYI8vq8tDlq20PjSPUOEOQmA1ESr9DXRF3YZwtevTb03Seg4/oNUSS9vKkh0hCvz04WBQZvROjW7cw7dDmyB05OvIsyt9LtqHvAMLgH3B9CDx7y6HwUjUJ4LCfjyVO17+Rrevb8hacLL191RyEjXstW65u3PT3a2b57zzm6PnR+7NaVqyWN+yT39uFzUVFfL2OwcI5IEr7oqn1Vkd1eXJyfn2KhV8ocieCbfuP9/eR5pgfffzT91JB52B2OB9LI81/qtUPEwDJMJfQdiKP/Efz+oy0FDGwXYg3dlx+BwbwkjDFEmRu8ZvGBv7FZRol/3T2xhRzFta4AAAAASUVORK5CYII='],
+            ['quick-inventory', '#showItemsModal', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADgAAAA4BAMAAABaqCYtAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAACdQTFRFAAAA0KhgoHhA+PCw+OB46MhgQEhoqKioeHh4WFhYuEgA2GgAgCgAQaYPaAAAAA10Uk5TAP///////////////y0EQa0AAAH3SURBVHictdTNkpNAEABg5IBXe7bgnGGJOSuU3kmT8koq4xnWdZKjFasSHsBKyBuQV/AR9OKj2TP8zMCa1YtdRULPR1MzTIPj/D1ewKsbieO4d/Fbk93Hb2aOncbJkLvL2L7UjacYm9L5J8K0zyLCd+sBcxYnaBCXMfeH+0CAiFnRZt6GkhJmA0KEKLrUFYgpDOgBPKKAoM1KELgCKAyynIUh6AhD7vMRBms1xzaSdF6OK40pHVcyjK3Af0W9lBFaS3kWHf4UmWOjPdsnqErfH49fVeEIS4WoTCkqDCx8pBGsFdbqbGVjsKeRD7WOb3S6KA16wWGM27IwyI50X4LuZ3XkBt1wt9+gLqJyzBancHgG7l3y+rzf9Jgtqofl0Ln3ccJ354PsYlud2LLvXFdtA9vV9VVHXZ+42qTZgBEwOQSH1CDNPULVPG0AYEpDBmklmS905NS3Bj1kcorff/74pXErL9fbWNUyuoWefICbSC30DNJLNEVhLeV/4ZyOHgnWwjwhQhodUAiFhUHfxtzGTPA819W6yveZ2PRIl3LwgbfIIAdGd+la7DMAvefA228CoyMA+Nh3Ju3+GGnA9CZtm43y4NixraQV5ynWzbWLSz3Bl9Xl0mPTnL+M0NOVTaMuocpihI6k4Ua9ZPTXSGcSnplPMbU/xm/a6CAG6AGINQAAAABJRU5ErkJggg=='],
+            ['quick-pokedex', '#pokedexModal', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAWz3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjarZtpduQ6doT/cxVeAjEDy8F4jnfg5fsLgJkaq/zc3VJJmUqSGO4QNwJAXfN//ntd/8VXzMZfPqQcS4w3X774Yitv8n2+6v5tbr9/n6/+vJqvn1/vC5aPHK/u/Jnjc//rc/Nu4LxU3oVPDeWnIdO+Xij+aT9/a+jpyGlEljfjaag8DTl7LpingXqmdceS0+cptHlen+ePGbKmxq8y9q23Kc9ovv3tE9YbgX6ctdMZd/PbOnsG4PRjL1d5E/htXOBG87xP/ObrGQkG+c1O96dRXT+88npn/vD5N6e4eD6/+OCrMeP79dfPTfjd+Nc28aeeXX/3/OXz0F4W+2pk/aw18rXWPLOrPmLS+EzqNZX9jhsbJnf7sch34ifwPu3vwne+iN6OyweB2fjuphiLW5bxZphqlpn7tZvOEL2dNvFqbbduf5ZdssV2d194yOvbLJtcccNlnNlxr+NT+x6L2f2W3V03mY6H4U5raMwc99v/zPcfG1pLIW/Mnd+2YlxWQcgw5Dn95i4cYtYrjsI28Ov7+5f86vBg2GbOTLDe7TTRgnliS3HktqMdNwZeT66ZNJ4GMBF9BwZjHB64I8FvormTtckY7JjxT6WhbJ23DReYEOxglNY7F3FOtuqbZ5LZ99pgz8dgFo4ILpJIGQdVfCVgI36Sz8RQDS74EEIMKeRQQo0u+hhijCkK/GpyyaeQYkopp5JqdtnnkGNOOV+55FpscYBjKLGkkksptdJppeXK05Ubam22ueZbaLGllltptRM+3ffQY089X730OuxwA5wYcaSRRxl1mkkoTT/DjDPNPMusi1BbbvkVVlxp5VVWfXvNXMetP77/udfMy2t2e0o3prfXeDSlVxNGcBLkMzxmvcHjSR4goK18dlNDvL3kOvnsLpasCJZRBjlnGHkMD/ppbFjm7bsPz33x2+X9v+U3+/LcJdf9Jzx3yXV/8NxPv/3itVF30XTX9pDSUEa9HenHTdVm/lGT/v7q+ljTBRyYy9ViWovU8TRukqWAU8RbWz3i4WJc7IvGJ7BWFh1MX9edqwqnWvt4vb5/YNugm7smddNSUTNKUb3SkxnvnozXZ+qLCc+LrpY+oDNHO8vnfzivb69Edp2+9QA600pZt5xsRg6A7JgdPAbZSyaICKw5bMiJcOyr19jq0DxXHoyXhqzD6aooALbGtqvJbXQV7G7rHvq0L3poepdm3fdNwiW9b7nW645znathglfwEhninzd1cc+fm6qe1Iwr51F9yjV1N+Ii2p2CzfRmxrCdgJzgkUkgfE8xOubdbes9zXGXmYcPnYhqZoVaB+9DbeSda9bNvHi+Uf1y7m41X0u65O1gOxFqHJUw87FNJGSI1Ta7ah/ejXtNUsGSYyuV+O4pPQ9V0OTirxgrcRKNuqN9ulox++Vjdc8jIZBsbjYXiP1249pR1pj46OnWrOt5pDITJlFqNviPoJt9zfUx0jZcm/K6j0OVeICh5K1pkwyexYar2FmqiAHg1ECF7Fq7yVIAZQagKW6PDTqvIzbPv5kY+LaoLOUmQLvmuGwZc6Uw/Eo7q3IYaRrl2bIjJIaFLfAsaLbW+yKp8eUyucYdrVuiHHPOROqnf62567T3bo5sq2QMpf9kjImzgglgYFDGJNvhQwI+oNjiiuCfyCFp3yljSRTly0w7X9TBEgqHORclIRCk5tfX0Imj7h2kKsyVffPUbyLGWuDDBrmBsmETxaARdK3M7pNbjHsJzR4DWL8NcA3btgXKscDtxphMzT3IN8MGPoYm4KN5mMzdKmGwkcrNULHRWPUqO/14IJky7cAozIm0CoGO+TYtcjHPW/UL2LtDv7HK6IUYiZQkR+wx4suRidFUaglh6mpqpagiRWLWAa3QEzjC8qGSg835vvyObWhPSYptEsm72Q1Ju4SnUB+Kh8VEws2Il8kyd3KMqhG4qTDoNWlwgBXUNlctCo0MCLkNkpYKVTCoD7m37BBJN6T0dryfVLDtO6DRnTApq7S5VpvCwFz4vJLyjqi+hpmT2tUIF8ZUQhh9OXC46daJZ2PemO6WS7RKwtMipK3PSWCZCCbZuYoVYwstU5bJMhzeK7lkiTLcB4/D5dkrVplCphTlStqD5BlDwaexNgCZ9cn15aNSWhGiqZhF3wGChVcdpsGEPz65zb6XOoFZrhAHTkVTESOgIfV25tgAQSzTKFky79rmZYghesg6mO1CJaoqaIOxadj1y3koCw6Oifxv+HtASjEmDsttYyCBGFtzx/mlfXZkjLluzGikSFsDDOlZEbNKWq3iGuCTv5CGPFZJjP3YZMR3IDq8UhzfUWgYccZ6Da/hMOL+hvCA76Boj7COMUfxLjbrM8xLxKcEgN5EJojI3Qk3d2hMkwKB4K41UycjaZ+A2LFixHEcrDoQENRJsBYTTl/mpNQxc4rVjq5Xyu2Eu3bGKeGUbiQgBnjQoCUP8hPqEzTY+QYoi1WGeIMGthKBXpbGDs4gjsdfWM8/Jz3XN9aDm1UWCRgAiOpGEuB8YDMkh+hbOaZKC9tT4CG4FwRvIV2ly8XDP3hn8DuFBM9YiJ7qR7o30FRjR4pUXP/79et1g13J4emNfMIdUMVkTS/M/UCd5wFvI/6qP65fn28A6VWYwf0pHovJKgT1ZTubY8XjZlZhKglGkaNyRqAYV10rMIiEXawLpM4PbDd+7iYJWgczjmRZGwpicgdMgzAT6Wvj0cILJ/mSIjLfq+QOzQIk8MNdVepOhbFx7ArjzakwoigElaqMGNuJej/ayZo7HxKVG5FPyYJ+2++MFWw6hI+PaF1876L5YyOK07t5Q6Tvtp0yKmM22i2nhmL3QXd6JkDlqPcLoVOwkdQmE6YGwwImFQF/AE7ODUQBfU2yxFGZZTOK564GsJP9550yI6KIwyGJiESXI+lpCEft0Nyloq2BG7QP5sXZMzb0BWlEdANrZaoqUQtXuQMNXFO0oNzE5R4skLEckYJ+KSrB4u1+npCc1oFHwWTcb0DnsZsxuci9V0ALpTZTObFNYW19Oz5oiQcWilsJ/h10VJaFbBqldkKY5twEwAb51Ps1ZLNvaQvonvHlNAtciwTcJKYSMTsFEUuYlLzrGI1ZA4KUo/tDWryExdYVYjjSFUrnv8fSuFO5RKZfQTzjvrgRy6UXSZAoW/VUtzzDB6jplueGW4Rd9/C4gC0/DcrO8EzrYkG3I1AWNTfz3cLyIlvJN2ccRVucQjhKXRPGkQeUqhfV/VLiDS/DieVCBxzUeRNQK1owbAVJUxq0+qbHJIIrKITWjIGWkP0LXhdppmt8ynlFcVHYUX6RAcnhhtSIg60BEMdi3TVRWRACJ9Pp3N9zKFyc2Rwg5aE0XnZ7r4fHUgWpe5hBv+IUupQNaNMKsKpFdhmAO/gKsBYSgIrYYIERLQ7bgmbQqU0wDpH6HWHhCvB8EiJQsvBBF0afdklcM1TvNgqGByXTAcGwUdKDAGXATJpxkutxgg8dFYFIjx+tasAf7WqdlT96gH4OEIHxZnRlVFD5zNTsjoJETR+V8f4Vq20gkPGq7dkR9jfljAzCVdx/WSicOP0ybTdJAT/cH7z+i7HBCkA1wcIl6DDmdRKU2PIfgt20sGOcyNmTSpjGudDc70msWkX2nzx/8t2VCC+G9aCWmHgC+lcjNZcGxHRDJJImSThARbCNwGV+iErcL1vHrDCGMo1Ogfz8JGVpJ1WG6Tjy3XXXEr5ITbJWZIWiaDHZBdn0Efy44V4OZuRHwiOUFKKiZmaoSMXkuWo1SCFWKGiu3c7TvZliyGnc0Jpfc/lzKr9Ewx/xYOc6AQntzi8b+S+kPIpsAYKW1nrT4jjKklBfzcIr5urMQP2R8u0S5EsDUGmZBsSodjgboaka5ASoA3zAWnDJ4nBfUmkArLF8ge0DKJFotpeJFuSnfkDBU7v98F/9mOjlnpv13wjwtQCgU0Ap4OBTQhEXeOflR4XsN79u22PvdH1rIyR3mLD0WQ1xW60rcpWWRG6QiBCME7UF8URa+kvL4VBitW0QaebVd9h9q8T6sRdAvrSzM6A9GdDvAfiH1tApDeUXlYbuztTGXm/aLE4MEko6S6/BEnZ3xBOwDuK73VBGkBFue/hRgkJYtM+gC4K2JtEerYkEj/lbcjcDpnYRWSac9a1PbNyddmjkOq0QG1rVmNE4SlPLQ/oIrw8fYYmkfpVExspSH+DEWWlKVv7cExwXFDzz3eAMN1rSRtHzJPAld79m6ZOjjBPEZvQ+PbQUfjyuZLRq4CxQeFdka9ZiEs615nv5tZ/y1fUHFQjcW/yegOxCXvciPZ8pzy+MhxZB1FRQRowQK0CO6+7pgsMT5+9ux07WpWRV0tI88uehVRh27tDE7FVUKYp4Z3Qns4QfQcZ4/HCRHd3mW3B/kJOyduISLenQ0Xjo6NocEkK2DiEd4K9YRgZJKIL42GnsYQ8XjkbAvmlk3pogAKKD2G/u+lKfyxA1s7C79MiEagGnMyRSYPYf7PmsjyYCctt9978FOnW6mJHnqS4mf8Y4LSkK5fr66Rr4EemNJj3UmonjhId4osx7/7k48wM9d7vXD6Lbl6YH2WyKOMgYxiG0tmmW06rg28X1LA1VSK2MrWbNM9x9IdzttOoUS7/QvMPyCiwvb5b3MP8pEPwkCeDtWOyOWw/Inaq3a31aiAap+IcIf7CP+DHXsT12tkM0GW/vqY4uKMJa8Fc09l+uKr7gFNdLIIZC5ikWEOHjD+zfnoDqUwudNe0BxQrYhtouOfGJ/RP5Zf2UUg1wBC4pC1Hmu7eVtmcbDHZnxfU5uBoWQud3aWwt5xTBeAyPxoZ88q8ZSWxzq0SeZeKzNH1BxyCuVgtu41CDqcUXbQ1pXWGbPN0vk7/W/olZ3DZk6M2oCgrSGEH6lBhYWpGBxFjxzQEHpjueDcvCHWr25YZ3eqmPDjdhvIwNSjU60hWipUVbyXUiccMV4JsFgZCALdR64Z6EPNTWDwHVfcdKblGHQURssEnH9bAOrbCgeg7ZKjvs4UmqAW4vZ4/OzYwtaRP4fSs3Cv61TncRGFau2qvQseKx0UpukwyZCpTRqx/kbrg7IrVMrVjL6wNhmVWitDQ9bbzOuqGvpYkMDW0FLGNDmVkJ11Tec64JltfAWIxPTYkUiVvgX4OWUBWw5rInYtsTsWtDc4AyCe52qYblyzNwG60ZTeaxXgSTsuREMMnCizzb+4DwSzL0c1T9/9Lm+pE3xjfF3W3hUGVMwv8vTrMN6KcQh4g6ag4cAXnLn/x0CvWtQi1qRYmc3ahQa/3PkVbAegLYsuGWKOmLRzE5UOEJN7KtkxtOfA7FRMXPmvukwoUd6FmCYO/gxAYbwXywfq1KqksiSurhiI4tObokR1ctQegAV+S+KiFlq/SoLSF7CP4FJa4SVKsK3eF9sCF4TPO9aY8SDqGfMbWAhN+tT4lRgZsNo2r9bCs4I68lbdtX4xBhuWT3URXTSVVS0u99KGXk3mNace8xpU3AnouX5niu3/e5Q7tUCffT4QZl7eopTAEpFP6zcSaWww8xDB7B2WmIqldcGECeL9oJ5cebGHtJsN3KQ+jfokWu0mdE4yiZ6yGkmZLzQJDW/A8GnVX/IIgBaAQzXSt+GsxwezAMdu/h7R219MCPtnX3htq18Wc2wAe/RwggCSJS2SoP49ZEbhGFI9jus5eEul223iFLChxYtSwpD67pmt9F6piVKJiPWcvbrPbszzidITnr7GNo9QooPdszeOcSWGpdaKazKL/1D6oEvBG4rfFokrzT1BOjECduTsFrWbYd8xvq2k0/5RnUe0iPL8sXX+6BycTP0L4M7BLIbww/sGIPQm5c2agisYDZ5ll5+/OILwiTFc+HzKwM0EcqMeyS3+P2KKJWqGXVgZqOoEAMaPsnwusRgLCFOxYRPeVaf60WofrjThYSdJltEoT5vlKmOxt2qTet9/EGnYDo0OWiSyeyDW4+MmVvXqB74jahxHXb4lrryViz7l2hZ/JhT/4FZhdgx3MlJfQfcsRpOc5Eh8pM6NtoAEqlfaI7rVy/AGTrmygHNVXEbq9MfEmetG1mQk7rX4BE6EeS+nb2MoQXcfNK4GKKgR0pr9N3TDxfII5uNVbUTfX1qAxlTn7WZL4MQAJrD+HzCOj/+jSAn91/6Zyu6fNP8He1UpACXuo+QDRGs1ZyHkQNxjgDSUWSt7iVfAjuj65QZA9teLW3P+pP9fh7gMzpOs/dY7jWL4iu90Tp1Pri8BBl50qLIaDWQwi2auOGbNfJookB4KhaPraqOePZGUGT5Uu7Q0rB8DkF28lQrscziXMDht630BC3fD734Pr1r2xdfNu5gCCted19n8d4doy1aPY+agFlqjCglY/2tjZpLtCgvWPU8tQeqolH5Vz3z/MeWAlRsTdXDVQNsrrHQClSu3+gZNfDyTTNWb+1SVH9FDbfFuuonHl8XL9+ueEvZ2BIf60b2LtqUbs1cfA7qMmdIn+6+OvBlnOs5cehluv3peffjrT8fXPq+qcuJjePPWx97HXKBcIMURrb9bcbZO7XcJ7Ns1/O+ZzXS1Ga/ul5o8fWOib2YVAdjQ1kPzZ92fu3G/5k8++Hia7fTxP9n4eJXLGS9XDcpq39mS/0EoRKGPP5rEzvJmlXCr1ttK9PKZY77hrc68gAhW0fGRjnxMClRVjtde6Ke6D1dffXe7kxGB1zKTro6m7UoVYmC8KvJJ0bqQh/akjWgtRUkarJFe9G485JKr2PKv3xpNIe0sWTz9LZLi2M4F3bNprnsdFcJyecqPge+o4QyWzXXouc1y7gr1XOA2hCjk05egv+wFl44Gyr8HPKiSKPmQNKdfiJFqkmx+G0aRTgrh7lklEu9t5HhJ4lsOyhxDvmC92IN3V7Gg5qeFOP68D994XKss9D3SI6XzSNqpr5snD+0jXXPrey7vfK+VE25kVjyojluLvrfN7UntzZr8hfx3r9Mtg0/rAMVWqeTX6F3lhw1PrOV9E+mk6M90g95GkdwRLomV05BHt2V1OxWRuVwf4P3lTtu6y2TrQjEndxPjsiYgUiB5sWaPfiGNqJGKRez8qjOdzoCZ7rI3qUnsqiRqnc8ZvgMUSlZybQbhJmkkCwoBQrNE3ha0SQXCGT2kVcr0dSGPusAIT3CoD0xrOFx0CUzWYeHHXWaftOGX0rgK9gyz75c9jzPvqzFyKwUpw7TcwWrXIHUOcB2ARtaPsUYPJDJ46d09JYRYmndD8bB0Tqbx57e06JfbaDkz3bwanuinZpSWLgVKu91A7AW6FgLbA95pfAG8ELhEmHGBBNWmGJTgc79iEGMdWGZ9b1OtzFDM/hrnFOb211wOy2eHguPuIhfRIPUXVbO9NXXf+RpsrVsOHZbA4UEyLSHLQukQpUiVr0wKFSsGOvJV68KiY1tPGeGyS+ER/xCreWxZq9bcUwU4ZfVCpzKNRm7CcYRct/4+v3YewqRw9jfzYENq4pHc9n6wdrH49o+EoJr39dNHzVDNf/IRre3UsW7gFsSPngpFqo1wiuv1jhq7B/dL125VwwP8Z1vcSMiuvNg2TXRHbMYhDcsF2yNHDvjcRmdHGEEoKv2rJDe/e6c9ZRsa7NV2rM/248XR+x+e81db1is9xnQ/+UwfcBxI91h6UzhiA2aBCLk389RYesbbmNYq9Q9L86IA+tainco+16PcpDUPC304tfXq8fi/gz/vXcyOY3vxDA68Xx/wJCH2C00fH3ky/XOfry6uovVOr+dOjhl/ldX+fFGAut/y++qc+OAKk1OgAAAYRpQ0NQSUNDIHByb2ZpbGUAAHicfZE9SMNAHMVfU0tFWjrYQcQhQ3VqQVTEUapYBAulrdCqg8mlX9DEkKS4OAquBQc/FqsOLs66OrgKguAHiKOTk6KLlPi/pNAixoPjfry797h7BwitOlPNvnFA1Swjm0qKheKKGHxFABGEEUJcYqaezi3k4Tm+7uHj612CZ3mf+3OElZLJAJ9IPMt0wyJeJ57etHTO+8RRVpUU4nPiuEEXJH7kuuzyG+eKwwLPjBr57BxxlFis9LDcw6xqqMRTxDFF1ShfKLiscN7irNYbrHNP/sJQSVvOcZ3mCFJYRBoZiJDRQA11WEjQqpFiIkv7SQ//sOPPkEsmVw2MHPPYgArJ8YP/we9uzfLkhJsUSgKBF9v+GAWCu0C7advfx7bdPgH8z8CV1vVvtICZT9KbXS12BES2gYvrribvAZc7wNCTLhmSI/lpCuUy8H5G31QEBm+BgVW3t84+Th+APHW1dAMcHAJjFcpe83h3f29v/57p9PcDbYFypYJjNYkAAA+caVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA0LjQuMC1FeGl2MiI+CiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICB4bWxuczppcHRjRXh0PSJodHRwOi8vaXB0Yy5vcmcvc3RkL0lwdGM0eG1wRXh0LzIwMDgtMDItMjkvIgogICAgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iCiAgICB4bWxuczpzdEV2dD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlRXZlbnQjIgogICAgeG1sbnM6cGx1cz0iaHR0cDovL25zLnVzZXBsdXMub3JnL2xkZi94bXAvMS4wLyIKICAgIHhtbG5zOkdJTVA9Imh0dHA6Ly93d3cuZ2ltcC5vcmcveG1wLyIKICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIgogICAgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIgogICB4bXBNTTpEb2N1bWVudElEPSJnaW1wOmRvY2lkOmdpbXA6NzMwODk4ZTQtNmFlNy00OTg4LTkxY2QtMWZjNzljOWM2YWMyIgogICB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjdlN2U2MmY1LTIyNWMtNGU0YS04NjlhLTJmYjRlYzg1ODUyZSIKICAgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOjk0YzQwZGZmLTBkODctNDc1Ny1iZDNlLWZhZjQ5ZDg5MTU3ZSIKICAgR0lNUDpBUEk9IjIuMCIKICAgR0lNUDpQbGF0Zm9ybT0iV2luZG93cyIKICAgR0lNUDpUaW1lU3RhbXA9IjE2NTI2MjA2NTQ2Mzk5MjQiCiAgIEdJTVA6VmVyc2lvbj0iMi4xMC4yMiIKICAgZGM6Rm9ybWF0PSJpbWFnZS9wbmciCiAgIHRpZmY6T3JpZW50YXRpb249IjEiCiAgIHhtcDpDcmVhdG9yVG9vbD0iR0lNUCAyLjEwIj4KICAgPGlwdGNFeHQ6TG9jYXRpb25DcmVhdGVkPgogICAgPHJkZjpCYWcvPgogICA8L2lwdGNFeHQ6TG9jYXRpb25DcmVhdGVkPgogICA8aXB0Y0V4dDpMb2NhdGlvblNob3duPgogICAgPHJkZjpCYWcvPgogICA8L2lwdGNFeHQ6TG9jYXRpb25TaG93bj4KICAgPGlwdGNFeHQ6QXJ0d29ya09yT2JqZWN0PgogICAgPHJkZjpCYWcvPgogICA8L2lwdGNFeHQ6QXJ0d29ya09yT2JqZWN0PgogICA8aXB0Y0V4dDpSZWdpc3RyeUlkPgogICAgPHJkZjpCYWcvPgogICA8L2lwdGNFeHQ6UmVnaXN0cnlJZD4KICAgPHhtcE1NOkhpc3Rvcnk+CiAgICA8cmRmOlNlcT4KICAgICA8cmRmOmxpCiAgICAgIHN0RXZ0OmFjdGlvbj0ic2F2ZWQiCiAgICAgIHN0RXZ0OmNoYW5nZWQ9Ii8iCiAgICAgIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6MGIzZjhkNTAtNjQ2My00NjJlLTkzZGEtOTM0OWNhOTE1YWFkIgogICAgICBzdEV2dDpzb2Z0d2FyZUFnZW50PSJHaW1wIDIuMTAgKFdpbmRvd3MpIgogICAgICBzdEV2dDp3aGVuPSIyMDIyLTA1LTE1VDE1OjE3OjM0Ii8+CiAgICA8L3JkZjpTZXE+CiAgIDwveG1wTU06SGlzdG9yeT4KICAgPHBsdXM6SW1hZ2VTdXBwbGllcj4KICAgIDxyZGY6U2VxLz4KICAgPC9wbHVzOkltYWdlU3VwcGxpZXI+CiAgIDxwbHVzOkltYWdlQ3JlYXRvcj4KICAgIDxyZGY6U2VxLz4KICAgPC9wbHVzOkltYWdlQ3JlYXRvcj4KICAgPHBsdXM6Q29weXJpZ2h0T3duZXI+CiAgICA8cmRmOlNlcS8+CiAgIDwvcGx1czpDb3B5cmlnaHRPd25lcj4KICAgPHBsdXM6TGljZW5zb3I+CiAgICA8cmRmOlNlcS8+CiAgIDwvcGx1czpMaWNlbnNvcj4KICA8L3JkZjpEZXNjcmlwdGlvbj4KIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAKPD94cGFja2V0IGVuZD0idyI/Pn9Za1QAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAAHdElNRQfmBQ8NESISKzy+AAAA3ElEQVQoz5WSIXrDMAyFf3cBA4MBPYKPIRjoIwwWFg7mCIU+QqCgoeBgYGDhQA4wpoLGWZaFTMRP+t57ki0HdiEivs3NLGzzZk+8mO0d/I9QRHwAH2P07/zhY4w+xugD+ADeg1fDUxXFGInXBO/981xqAHHT8EVE/GJG27bMnxPt6xfTTVfCPM8AvN3vINI3WyeA6aZcz2cO71NHqoSKSymklMgiTxPAFtwAlFLoum4V5Zx/8EJMKaGqhPpKpZSVVMUppbWmqphZOB251pGOIuwXtyeq6q+Nh/9+jQcRyGEasqbeQgAAAABJRU5ErkJggg=='],
+        ];
+        shortcutsToAdd.forEach(([id, modal, source]) => {
+            const quickElem = document.createElement('img');
+            quickElem.id = id;
+            quickElem.src = source;
+            quickElem.setAttribute('href', modal);
+            quickElem.setAttribute('data-toggle', 'modal');
+            getMenu.prepend(quickElem);
+        });
 
-    function generateRegionGymsList() {
+        // Add AVS settings options to scripts tab
+        const settingsBody = createScriptSettingsContainer('Additional Visual Settings');
+        let settingsToAdd = [
+            ['poke-name', 'Show wild Pokémon Name', 'wildPokeNameDisabled'],
+            ['poke-defeat', 'Hide wild Pokémon Defeated', 'wildPokeDefeatDisabled'],
+            ['poke-image', 'Hide wild Pokémon Image', 'wildPokeImgDisabled'],
+            ['poke-health', 'Hide Pokémon Health', 'wildPokeHealthDisabled'],
+            ['poke-attack', 'Hide party attack', 'wildPokeAttackDisabled'],
+            ['poke-catch', 'Hide Catch Icon', 'wildPokeCatchDisabled'],
+        ];
+        settingsToAdd.forEach(([id, desc]) => {
+            let elem = document.createElement('tr');
+            elem.innerHTML = `<td class="p-2"><label class="m-0 col-md-8" for="checkbox-${id}">${desc}</label></td>` + 
+                `<td class="p-2 col-md-4"><input id="checkbox-${id}" type="checkbox"></td>`;
+            settingsBody.appendChild(elem);
+        });
+
+        document.getElementById('checkbox-poke-name').checked = !this.wildPokeNameDisabled();
+        document.getElementById('checkbox-poke-defeat').checked = !this.wildPokeDefeatDisabled();
+        document.getElementById('checkbox-poke-image').checked = !this.wildPokeImgDisabled();
+        document.getElementById('checkbox-poke-health').checked = !this.wildPokeHealthDisabled();
+        document.getElementById('checkbox-poke-catch').checked = !this.wildPokeCatchDisabled();
+
+        document.getElementById('checkbox-poke-name').addEventListener('change', event => {
+            this.wildPokeNameDisabled(!event.target.checked);
+            localStorage.setItem("wildPokeNameDisabled", this.wildPokeNameDisabled());
+        });
+
+        document.getElementById('checkbox-poke-defeat').addEventListener('change', event => {
+            this.wildPokeDefeatDisabled(!event.target.checked);
+            localStorage.setItem("wildPokeDefeatDisabled", this.wildPokeDefeatDisabled());
+        });
+
+        document.getElementById('checkbox-poke-image').addEventListener('change', event => {
+            this.wildPokeImgDisabled(!event.target.checked);
+            localStorage.setItem("wildPokeImgDisabled", this.wildPokeImgDisabled());
+        });
+
+        document.getElementById('checkbox-poke-health').addEventListener('change', event => {
+            this.wildPokeHealthDisabled(!event.target.checked);
+            localStorage.setItem("wildPokeHealthDisabled", this.wildPokeHealthDisabled());
+        });
+
+        document.getElementById('checkbox-poke-catch').addEventListener('change', event => {
+            this.wildPokeCatchDisabled(!event.target.checked);
+            localStorage.setItem("wildPokeCatchDisabled", this.wildPokeCatchDisabled());
+        });
+
+        // Create travel shortcut buttons on town map
+        const travelShortcutsToAdd = [
+            ['dock-button', 'Dock', {left: 32, top: 0}, MapHelper.openShipModal],
+            ['gyms-button', 'Gyms', {left: 75, top: -8}, () => { AdditionalVisualSettings.generateRegionGymsList(); $('#gymsShortcutModal').modal('show'); }],
+            ['dungeons-button', 'Dungeons', {left: 121, top: -8}, () => { AdditionalVisualSettings.generateRegionDungeonssList(); $('#dungeonsShortcutModal').modal('show'); }],
+        ];
+
+        travelShortcutsToAdd.forEach(([id, name, pos, func]) => {
+            const button = document.createElement('button');
+            button.id = id;
+            button.textContent = name;
+            button.className = 'btn btn-block btn-success';
+            button.style = `position: absolute; left: ${pos.left}px; top: ${pos.top}px; width: auto; height: 41px; font-size: 11px;`;
+            button.addEventListener('click', func);
+            document.getElementById('townMap').appendChild(button);
+        });
+
+        // Prevent ship modal sequence-breaking
+        document.getElementById('dock-button').setAttribute('data-bind', 'enabled: TownList[GameConstants.DockTowns[player.region]].isUnlocked()');
+        ko.applyBindings(App.game, document.getElementById('dock-button'));
+
+        // Create gym and dungeon shortcut modals
+        const modalNames = ['gyms', 'dungeons'];
+        const fragment = new DocumentFragment();
+        for (const name of modalNames) {
+            const customModal = document.createElement('div');
+            customModal.setAttribute('class', 'modal noselect fade');
+            customModal.setAttribute('tabindex', '-1');
+            customModal.setAttribute('role', 'dialogue');
+            customModal.setAttribute('id', `${name}ShortcutModal`);
+            customModal.setAttribute('aria-labelledby', `${name}ShortcutModalLabel`);
+            customModal.innerHTML = `<div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-sm" role="document">
+                <div class="modal-content">
+                    <div class="modal-header" style="justify-content: space-around;">
+                        <h5 id="${name}-shortcut-modal-title" class="modal-title"></h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">×</span>
+                        </button>
+                    </div>
+                    <div class="modal-body bg-ocean">
+                        <div id="${name}-shortcut-buttons"></div>
+                    </div>
+                </div>
+            </div>`;
+            fragment.appendChild(customModal);
+        }
+        document.getElementById('ShipModal').after(fragment);
+
+        addGlobalStyle('.pageItemTitle { height:38px }');
+        addGlobalStyle('#quick-settings, #quick-inventory, #quick-pokedex { height: 36px; background-color: #eee; border: 4px solid #eee; cursor: pointer; image-rendering: pixelated; }');
+        addGlobalStyle('#quick-pokedex { padding: 2px; }')
+        addGlobalStyle(':is(#quick-settings, #quick-inventory, #quick-pokedex):hover { background-color:#ddd; border: 4px solid #ddd; }');
+        addGlobalStyle('#shortcutsContainer { display: block !important; }');
+        addGlobalStyle('.gyms-shortcut-leaders { display: flex; pointer-events: none; position: absolute; height: 36px; top: 0; left: 0; image-rendering: pixelated; }');
+        addGlobalStyle('.gyms-shortcut-badges { position: absolute; height: 36px; display: flex; top: 0; right: 0; }');
+        addGlobalStyle('.dungeons-shortcut-costs { position: relative; margin-right: 12px; filter: none !important }');
+        addGlobalStyle('#dungeons-shortcut-buttons > button:hover { -webkit-animation: bounceBackground 60s linear infinite alternate; animation: bounceBackground 60s linear infinite alternate; }');
+        addGlobalStyle('#dungeons-shortcut-buttons > button * { z-index: 2 }');
+        addGlobalStyle('.dungeons-shortcut-overlay { width: 100%; height: 100%; position: absolute; background-color: rgba(0,0,0,0.45); margin-top: -6px; margin-left: -8px; z-index: 1 !important }');
+        addGlobalStyle('.dungeons-shortcut-info { position: relative; font-weight: bold }');
+    }
+
+    static generateRegionGymsList() {
         const gymsBtns = document.getElementById('gyms-shortcut-buttons');
         const gymsHead = document.getElementById('gyms-shortcut-modal-title');
         gymsHead.textContent = `Gym Select (${GameConstants.camelCaseToString(GameConstants.Region[player.region])})`;
@@ -180,7 +190,7 @@ function initVisualSettings() {
         gymsBtns.appendChild(fragment);
     }
 
-    function generateRegionDungeonssList() {
+    static generateRegionDungeonssList() {
         const dungeonsBtns = document.getElementById('dungeons-shortcut-buttons');
         const dungeonsHead = document.getElementById('dungeons-shortcut-modal-title');
         dungeonsHead.textContent = `Dungeon Select (${GameConstants.camelCaseToString(GameConstants.Region[player.region])})`;
@@ -216,129 +226,114 @@ function initVisualSettings() {
         }
         dungeonsBtns.appendChild(fragment);
     }
-}
 
-function addGraphicsBindings() {
-    // Must execute before game loads and applies knockout bindings
+    static addGraphicsBindings() {
+        // Must execute before game loads and applies knockout bindings
+        const routeBattleView = document.getElementById('routeBattleContainer');
 
-    // Make variables accessible for compatibility with userscript extensions
-    (!App.isUsingClient ? unsafeWindow : window).AVSObservables = {
-        'wildPokeNameDisabled': wildPokeNameDisabled,
-        'wildPokeDefeatDisabled': wildPokeDefeatDisabled,
-        'wildPokeImgDisabled': wildPokeImgDisabled,
-        'wildPokeHealthDisabled': wildPokeHealthDisabled,
-        'wildPokeCatchDisabled': wildPokeCatchDisabled,
-    };
-
-    const routeBattleView = document.querySelector('.battle-view > div[data-bind="if: App.game.gameState === GameConstants.GameState.fighting"');
-
-    // Remove pokemon name
-    routeBattleView.querySelector('.pageItemTitle > knockout').setAttribute('data-bind', 'ifnot: AVSObservables.wildPokeNameDisabled');
-    // Remove pokemon defeated count
-    const pokeDefeat = routeBattleView.querySelector('.pageItemFooter knockout[data-bind*="App.game.statistics.routeKills"]');
-    pokeDefeat.before(new Comment('ko ifnot: AVSObservables.wildPokeDefeatDisabled'));
-    pokeDefeat.after(new Comment('/ko'));
-    // Remove pokemon images
-    const pokeImg = routeBattleView.querySelector('knockout[data-bind*="pokemonSpriteTemplate"]');
-    pokeImg.before(new Comment('ko ifnot: AVSObservables.wildPokeImgDisabled'));
-    pokeImg.after(new Comment('/ko'));
-    // Remove pokemon healthbar
-    const pokeHealth = routeBattleView.querySelector('div.progress.hitpoints');
-    pokeHealth.before(new Comment('ko ifnot: AVSObservables.wildPokeHealthDisabled'));
-    pokeHealth.after(new Comment('/ko'));
-    // Remove catch animation
-    const pokeCatch = routeBattleView.querySelector('div.catchChance');
-    pokeCatch.before(new Comment('ko ifnot: AVSObservables.wildPokeCatchDisabled'));
-    pokeCatch.after(new Comment('/ko'));
-}
-
-
-function addOptimizeVitamins() {
-    // Add button to vitamin menu
-    // (must execute before game loads and applies knockout bindings)
-    const btn = document.createElement('button');
-    btn.setAttribute('class', 'btn btn-link btn-sm text-decoration-none align-text-top');
-    btn.setAttribute('style', 'line-height: 0.6; font-size: 1rem; float: right;');
-    btn.setAttribute('data-bind', `click: () => { if ($data) { $data.optimizeVitamins() } }, class: (!$data.breeding ? 'text-success' : 'text-muted')`);
-    btn.innerHTML = '⚖';
-    document.querySelector('#pokemonVitaminExpandedModal tbody[data-bind*="PartyController.getVitaminSortedList"] td').appendChild(btn);
-
-    // Add optimize-vitamin functions for party pokemon (adapted from wiki)
-    PartyPokemon.prototype.calcBreedingEfficiency = function(vitaminsUsed) {
-        // attack bonus
-        const attackBonusPercent = (GameConstants.BREEDING_ATTACK_BONUS + vitaminsUsed[GameConstants.VitaminType.Calcium]) / 100;
-        const proteinBoost = vitaminsUsed[GameConstants.VitaminType.Protein];
-        const breedingAttackBonus = (this.baseAttack * attackBonusPercent) + proteinBoost;
-        // egg steps
-        const div = 300;
-        const extraCycles = (vitaminsUsed[GameConstants.VitaminType.Calcium] + vitaminsUsed[GameConstants.VitaminType.Protein]) / 2;
-        const steps = (this.eggCycles + extraCycles) * GameConstants.EGG_CYCLE_MULTIPLIER;
-        const adjustedSteps = (steps <= div ? steps : Math.round(((steps / div) ** (1 - vitaminsUsed[GameConstants.VitaminType.Carbos] / 70)) * div));
-        // efficiency
-        return (breedingAttackBonus / adjustedSteps) * GameConstants.EGG_CYCLE_MULTIPLIER;
+        // Remove pokemon name
+        routeBattleView.querySelector('.pageItemTitle > div:has(knockout)').setAttribute('data-bind', 'ifnot: AdditionalVisualSettings.wildPokeNameDisabled');
+        // Remove pokemon defeated count
+        const pokeDefeat = routeBattleView.querySelector('.pageItemFooter knockout[data-bind*="App.game.statistics.routeKills"]');
+        pokeDefeat.before(new Comment('ko ifnot: AdditionalVisualSettings.wildPokeDefeatDisabled'));
+        pokeDefeat.after(new Comment('/ko'));
+        // Remove pokemon images
+        const pokeImg = routeBattleView.querySelector('div:has(> knockout[data-bind*="pokemonSpriteTemplate"])');
+        pokeImg.before(new Comment('ko ifnot: AdditionalVisualSettings.wildPokeImgDisabled'));
+        pokeImg.after(new Comment('/ko'));
+        // Remove pokemon healthbar
+        const pokeHealth = routeBattleView.querySelector('div.progress.hitpoints');
+        pokeHealth.before(new Comment('ko ifnot: AdditionalVisualSettings.wildPokeHealthDisabled'));
+        pokeHealth.after(new Comment('/ko'));
+        // Remove catch animation
+        const pokeCatch = routeBattleView.querySelector('div.catchChance');
+        pokeCatch.before(new Comment('ko ifnot: AdditionalVisualSettings.wildPokeCatchDisabled'));
+        pokeCatch.after(new Comment('/ko'));
     }
 
-    PartyPokemon.prototype.optimizeVitamins = function() {
-        const totalVitamins = (player.highestRegion() + 1) * 5;
-        const carbosUnlocked = player.highestRegion() >= GameConstants.Region.unova;
-        const calciumUnlocked = player.highestRegion() >= GameConstants.Region.hoenn;
-        const prices = GameHelper.enumStrings(GameConstants.VitaminType).map(v => ItemList[v].basePrice);
-        // Add our initial starting efficiency here
-        let optimalVitamins = [0, 0, 0];
-        let eff = this.calcBreedingEfficiency(optimalVitamins);
-        // Check all max-vitamin combinations
-        for (let carbos = carbosUnlocked * totalVitamins; carbos >= 0; carbos--) {
-            for (let calcium = calciumUnlocked * (totalVitamins - carbos); calcium >= 0; calcium--) {
-                let protein = totalVitamins - (carbos + calcium);
-                let newEff = this.calcBreedingEfficiency([protein, calcium, carbos]);
-                if (newEff >= eff) {
-                    const newVitamins = [protein, calcium, carbos];
-                    if (newEff == eff) {
-                        // Choose cheaper version
-                        const oldPrice = optimalVitamins.reduce((sum, v, i) => (sum + v * prices[i]), 0);
-                        const newPrice = newVitamins.reduce((sum, v, i) => (sum + v * prices[i]), 0);
-                        if (oldPrice <= newPrice) {
-                           continue;
+
+    static addOptimizeVitamins() {
+        // Add button to vitamin menu
+        // (must execute before game loads and applies knockout bindings)
+        const btn = document.createElement('button');
+        btn.setAttribute('class', 'btn btn-link btn-sm text-decoration-none align-text-top');
+        btn.setAttribute('style', 'line-height: 0.6; font-size: 1rem; float: right;');
+        btn.setAttribute('data-bind', `click: () => { if ($data) { $data.optimizeVitamins() } }, class: (!$data.breeding ? 'text-success' : 'text-muted')`);
+        btn.innerHTML = '⚖';
+        document.querySelector('#pokemonVitaminExpandedModal tbody[data-bind*="PartyController.getVitaminSortedList"] td').appendChild(btn);
+
+        // Add optimize-vitamin functions for party pokemon (adapted from wiki)
+        PartyPokemon.prototype.calcBreedingEfficiency = function(vitaminsUsed) {
+            // attack bonus
+            const attackBonusPercent = (GameConstants.BREEDING_ATTACK_BONUS + vitaminsUsed[GameConstants.VitaminType.Calcium]) / 100;
+            const proteinBoost = vitaminsUsed[GameConstants.VitaminType.Protein];
+            const breedingAttackBonus = (this.baseAttack * attackBonusPercent) + proteinBoost;
+            // egg steps
+            const div = 300;
+            const extraCycles = (vitaminsUsed[GameConstants.VitaminType.Calcium] + vitaminsUsed[GameConstants.VitaminType.Protein]) / 2;
+            const steps = (this.eggCycles + extraCycles) * GameConstants.EGG_CYCLE_MULTIPLIER;
+            const adjustedSteps = (steps <= div ? steps : Math.round(((steps / div) ** (1 - vitaminsUsed[GameConstants.VitaminType.Carbos] / 70)) * div));
+            // efficiency
+            return (breedingAttackBonus / adjustedSteps) * GameConstants.EGG_CYCLE_MULTIPLIER;
+        }
+
+        PartyPokemon.prototype.optimizeVitamins = function() {
+            const totalVitamins = (player.highestRegion() + 1) * 5;
+            const carbosUnlocked = player.highestRegion() >= GameConstants.Region.unova;
+            const calciumUnlocked = player.highestRegion() >= GameConstants.Region.hoenn;
+            const prices = GameHelper.enumStrings(GameConstants.VitaminType).map(v => ItemList[v].basePrice);
+            // Add our initial starting efficiency here
+            let optimalVitamins = [0, 0, 0];
+            let eff = this.calcBreedingEfficiency(optimalVitamins);
+            // Check all max-vitamin combinations
+            for (let carbos = carbosUnlocked * totalVitamins; carbos >= 0; carbos--) {
+                for (let calcium = calciumUnlocked * (totalVitamins - carbos); calcium >= 0; calcium--) {
+                    let protein = totalVitamins - (carbos + calcium);
+                    let newEff = this.calcBreedingEfficiency([protein, calcium, carbos]);
+                    if (newEff >= eff) {
+                        const newVitamins = [protein, calcium, carbos];
+                        if (newEff == eff) {
+                            // Choose cheaper version
+                            const oldPrice = optimalVitamins.reduce((sum, v, i) => (sum + v * prices[i]), 0);
+                            const newPrice = newVitamins.reduce((sum, v, i) => (sum + v * prices[i]), 0);
+                            if (oldPrice <= newPrice) {
+                               continue;
+                            }
                         }
+                        eff = newEff;
+                        optimalVitamins = newVitamins;
                     }
-                    eff = newEff;
-                    optimalVitamins = newVitamins;
                 }
             }
+            // Optimally use vitamins
+            GameHelper.enumNumbers(GameConstants.VitaminType).forEach((v) => {
+                if (this.vitaminsUsed[v]()) {
+                    this.removeVitamin(v, Infinity);
+                }
+            });
+            GameHelper.enumNumbers(GameConstants.VitaminType).forEach((v) => {
+                if (v < optimalVitamins.length && optimalVitamins[v] > 0) {
+                    this.useVitamin(v, optimalVitamins[v]);
+                }
+            });
         }
-        // Optimally use vitamins
-        GameHelper.enumNumbers(GameConstants.VitaminType).forEach((v) => {
-            if (this.vitaminsUsed[v]()) {
-                this.removeVitamin(v, Infinity);
+    }
+
+    static loadSetting(key, defaultVal) {
+        var val;
+        try {
+            val = JSON.parse(localStorage.getItem(key));
+            if (val == null || typeof val !== typeof defaultVal) {
+                throw new Error;
             }
-        });
-        GameHelper.enumNumbers(GameConstants.VitaminType).forEach((v) => {
-            if (v < optimalVitamins.length && optimalVitamins[v] > 0) {
-                this.useVitamin(v, optimalVitamins[v]);
-            }
-        });
+        } catch {
+            val = defaultVal;
+            localStorage.setItem(key, defaultVal);
+        }
+        return val;
     }
 }
 
-wildPokeNameDisabled(loadSetting('wildPokeNameDisabled', false));
-wildPokeDefeatDisabled(loadSetting('wildPokeDefeatDisabled', false));
-wildPokeImgDisabled(loadSetting('wildPokeImgDisabled', false));
-wildPokeHealthDisabled(loadSetting('wildPokeHealthDisabled', false));
-wildPokeCatchDisabled(loadSetting('wildPokeCatchDisabled', false));
-
-function loadSetting(key, defaultVal) {
-    var val;
-    try {
-        val = JSON.parse(localStorage.getItem(key));
-        if (val == null || typeof val !== typeof defaultVal) {
-            throw new Error;
-        }
-    } catch {
-        val = defaultVal;
-        localStorage.setItem(key, defaultVal);
-    }
-    return val;
-}
 
 /**
  * Creates container for scripts settings in the settings menu, adding scripts tab if it doesn't exist yet
@@ -452,7 +447,10 @@ function loadEpheniaScript(scriptName, initFunction) {
 }
 
 if (!App.isUsingClient || localStorage.getItem('additionalvisualsettings') === 'true') {
-    loadEpheniaScript('additionalvisualsettings', initVisualSettings);
-    addGraphicsBindings();
-    addOptimizeVitamins();
+    if (!App.isUsingClient) {
+        // Necessary for userscript managers
+        unsafeWindow.AdditionalVisualSettings = AdditionalVisualSettings;
+    }
+    loadEpheniaScript('additionalvisualsettings', AdditionalVisualSettings.initVisualSettings.bind(AdditionalVisualSettings));
+    AdditionalVisualSettings.initOnLoad();
 }

--- a/autobattlefrontier.user.js
+++ b/autobattlefrontier.user.js
@@ -5,7 +5,7 @@
 // @description   Adds in stage resetting to the Battle Frontier that allows you to set a target stage and infinitely farm the Battle Frontier while being fully AFK. Also, gives the appropriate amount of Battle Points and Money without needing to fail and lose a stage.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.5.4
+// @version       1.5.5
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -167,5 +167,7 @@ if (!App.isUsingClient || localStorage.getItem('autobattlefrontier') === 'true')
         // Necessary for userscript managers
         unsafeWindow.AutoBattleFrontier = AutoBattleFrontier;
     }
-    AutoBattleFrontier.initAutoBattleFrontier();
+    $(document).ready(() => {
+        AutoBattleFrontier.initAutoBattleFrontier();
+    });
 }

--- a/catchfilterfantasia.user.js
+++ b/catchfilterfantasia.user.js
@@ -480,7 +480,16 @@ function addGlobalStyle(css) {
     head.appendChild(style);
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -497,13 +506,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -529,6 +532,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('catchfilterfantasia') === 'true') {

--- a/custom/autoquestcompleter.user.js
+++ b/custom/autoquestcompleter.user.js
@@ -5,7 +5,7 @@
 // @description   Removes the limit for the number of quests you can do at once and auto completes/starts new ones.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       2.0.2
+// @version       2.0.3
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -316,7 +316,16 @@ function createScriptSettingsContainer(name) {
     return settingsBody;
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -333,13 +342,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -365,6 +368,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('autoquestcompleter') === 'true') {

--- a/custom/autoquestcompleter.user.js
+++ b/custom/autoquestcompleter.user.js
@@ -90,7 +90,7 @@ function initAutoQuest() {
         settingsBody.appendChild(info);
         Object.keys(QuestHelper.quests).forEach((type) => {
             let elem = document.createElement('tr');
-            elem.innerHTML = `<td class="p-2"><label class="m-0 col-md-8" for="checkbox-autoQuestTypes-${type}">${type}</label></td>` + 
+            elem.innerHTML = `<td class="p-2"><label class="m-0 col-md-8" for="checkbox-autoQuestTypes-${type}">${GameConstants.camelCaseToString(type)}</label></td>` + 
                 `<td class="p-2 col-md-4"><input id="checkbox-autoQuestTypes-${type}" type="checkbox"></td>`;
             let checkbox = elem.querySelector(`#checkbox-autoQuestTypes-${type}`);
             checkbox.checked = !ignoredQuestTypes.includes(type);

--- a/custom/discordcodegenerator.user.js
+++ b/custom/discordcodegenerator.user.js
@@ -5,7 +5,7 @@
 // @description   Lets you generate infinite amounts of Discord codes for Pokémon that are exclusive and locked behind Pokeclicker's Discord bot & activities. No linking of a Discord account required + fully works offline.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.3.2
+// @version       1.3.3
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -77,7 +77,16 @@ function genCodes() {
     }
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -94,13 +103,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -126,6 +129,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('discordcodegenerator') === 'true') {

--- a/custom/infiniteseasonalevents.user.js
+++ b/custom/infiniteseasonalevents.user.js
@@ -5,7 +5,7 @@
 // @description   Adds in toggable options to have seasonal events infinitely run. Events can also run simultaneously with one another. Includes a custom event as well.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.3.2
+// @version       1.3.3
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -253,7 +253,16 @@ function addGlobalStyle(css) {
     head.appendChild(style);
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -270,13 +279,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -302,6 +305,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('infiniteseasonalevents') === 'true') {

--- a/custom/oakitemsunlimited.user.js
+++ b/custom/oakitemsunlimited.user.js
@@ -5,7 +5,7 @@
 // @description   Removes the limit for the amount of Oak Items that you're able to equip so that you're able to equip all of them.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.0.2
+// @version       1.0.3
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -28,7 +28,16 @@ function initOakItems() {
     document.getElementById('oakItemsModal').querySelector('h5').innerHTML = "Oak Items Equipped: " + oakItems.activeCount() + '/' + oakMax;
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -45,13 +54,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -77,6 +80,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('oakitemsunlimited') === 'true') {

--- a/custom/omegaproteingains.user.js
+++ b/custom/omegaproteingains.user.js
@@ -5,7 +5,7 @@
 // @description   Removes the cap on the amount of Protein and Calcium that you can use on individual Pokémon, and raises the cap for Carbos.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.1.2
+// @version       1.1.3
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -63,7 +63,16 @@ function initOmegaProtein() {
     }
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -80,13 +89,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -112,6 +115,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('omegaproteingains') === 'true') {

--- a/custom/overnightberrygrowth.user.js
+++ b/custom/overnightberrygrowth.user.js
@@ -5,7 +5,7 @@
 // @description   Allows berres to grow while the game is closed.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.1.3
+// @version       1.1.4
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -229,7 +229,16 @@ function createScriptSettingsContainer(name) {
 
 // load script
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -246,13 +255,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -278,10 +281,20 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('overnightberrygrowth') === 'true') {
-    loadEpheniaScript('overnightberrygrowth', initOvernightBerrySettings);
-    // Runs at a different time than typical script initialization
-    initOfflineGrowth();
+    loadEpheniaScript('overnightberrygrowth', initOvernightBerrySettings, initOfflineGrowth);
 }

--- a/custom/simpleweatherchanger.user.js
+++ b/custom/simpleweatherchanger.user.js
@@ -5,7 +5,7 @@
 // @description   Adds a button to select the weather for the current region, also freezes all weather
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.4.2
+// @version       1.4.3
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -68,7 +68,16 @@ function addGlobalStyle(css) {
     head.appendChild(style);
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -85,13 +94,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -117,6 +120,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('simpleweatherchanger') === 'true') {

--- a/custom/syntheticshinysynapse.user.js
+++ b/custom/syntheticshinysynapse.user.js
@@ -5,7 +5,7 @@
 // @description   Allows you to adjust and modify the shiny rates of everything specifically, as well as set a global shiny rate.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       1.5.2
+// @version       1.5.3
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -343,7 +343,16 @@ function addGlobalStyle(css) {
     head.appendChild(style);
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -360,13 +369,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -392,6 +395,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('syntheticshinysynapse') === 'true') {

--- a/enhancedautoclicker.user.js
+++ b/enhancedautoclicker.user.js
@@ -64,18 +64,9 @@ class EnhancedAutoClicker {
         enemies: null,
         areaHealth: null,
     };
-    // Visual settings
-    static gymGraphicsDisabled = ko.observable(validateStorage('gymGraphicsDisabled', false));
-    static dungeonGraphicsDisabled = ko.observable(validateStorage('dungeonGraphicsDisabled', false));
-    // Computed observables for visual settings
+    // Computed observables for visual bindings
     static autoGymOn = ko.pureComputed(() => {
         return this.autoClickState() && this.autoGymState();
-    });
-    static disableAutoGymGraphics = ko.pureComputed(() => {
-        return this.gymGraphicsDisabled() && this.autoGymOn();
-    });
-    static disableAutoDungeonGraphics = ko.pureComputed(() => {
-        return this.dungeonGraphicsDisabled() && this.autoClickState() && this.autoDungeonState();
     });
 
     /* Initialization */
@@ -178,8 +169,6 @@ class EnhancedAutoClicker {
         let checkboxesToAdd = [
             ['autoDungeonFinishBeforeStopping', 'Auto Dungeon finishes dungeons before turning off', this.autoDungeonFinishBeforeStopping],
             ['autoDungeonAlwaysOpenRareChests', 'Always open visible targeted chests', this.autoDungeonAlwaysOpenRareChests],
-            ['autoGymGraphicsDisabled', 'Disable Auto Gym graphics', this.gymGraphicsDisabled()],
-            ['autoDungeonGraphicsDisabled', 'Disable Auto Dungeon graphics', this.dungeonGraphicsDisabled()]
         ];
         checkboxesToAdd.forEach(([name, text, isChecked]) => {
             const newSetting = document.createElement('tr')
@@ -205,8 +194,6 @@ class EnhancedAutoClicker {
         document.getElementById('auto-dungeon-chest-mode').addEventListener('click', () => { EnhancedAutoClicker.toggleAutoDungeonChestMode(); });
         document.getElementById('checkbox-autoDungeonFinishBeforeStopping').addEventListener('change', () => { EnhancedAutoClicker.toggleAutoDungeonFinishBeforeStopping(); });
         document.getElementById('checkbox-autoDungeonAlwaysOpenRareChests').addEventListener('change', () => { EnhancedAutoClicker.toggleAutoDungeonAlwaysOpenRareChests(); });
-        document.getElementById('checkbox-autoGymGraphicsDisabled').addEventListener('change', () => { EnhancedAutoClicker.toggleAutoGymGraphics(); });
-        document.getElementById('checkbox-autoDungeonGraphicsDisabled').addEventListener('change', () => { EnhancedAutoClicker.toggleAutoDungeonGraphics(); });
         document.getElementById('select-autoClickCalcEfficiencyDisplayMode').addEventListener('change', (event) => { EnhancedAutoClicker.changeCalcEfficiencyDisplayMode(event); });
         document.getElementById('select-autoClickCalcDamageDisplayMode').addEventListener('change', (event) => { EnhancedAutoClicker.changeCalcDamageDisplayMode(event); });
 
@@ -230,32 +217,9 @@ class EnhancedAutoClicker {
     static addGraphicsBindings() {
         // Add gymView data bindings
         var gymContainer = document.querySelector('div[data-bind="if: App.game.gameState === GameConstants.GameState.gym"]');
-        var elemsToBind = ['knockout[data-bind*="pokemonNameTemplate"]', // Pokemon name
-            'span[data-bind*="pokemonsDefeatedComputable"]', // Gym Pokemon counter (pt 1)
-            'span[data-bind*="pokemonsUndefeatedComputable"]', // Gym Pokemon counter (pt 2)
-            'knockout[data-bind*="pokemonSpriteTemplate"]', // Pokemon sprite
-            'div.progress.hitpoints', // Pokemon healthbar
-            'div.progress.timer' // Gym timer
-            ];
-        elemsToBind.forEach((query) => {
-            var elem = gymContainer.querySelector(query);
-            if (elem) {
-                elem.before(new Comment("ko ifnot: EnhancedAutoClicker.disableAutoGymGraphics()"));
-                elem.after(new Comment("/ko"));
-            }
-        });
         // Always hide stop button during autoGym, even with graphics enabled
         var restartButton = gymContainer.querySelector('button[data-bind="visible: GymRunner.autoRestart()"]');
         restartButton.setAttribute('data-bind', 'visible: GymRunner.autoRestart() && !EnhancedAutoClicker.autoGymOn()');
-
-        // Add dungeonView data bindings
-        var dungeonContainer = document.querySelector('div[data-bind="if: App.game.gameState === GameConstants.GameState.dungeon"]');
-        // Title bar contents
-        dungeonContainer.querySelector('h2.pageItemTitle')?.prepend(new Comment("ko ifnot: EnhancedAutoClicker.disableAutoDungeonGraphics()"));
-        dungeonContainer.querySelector('h2.pageItemTitle')?.append(new Comment("/ko"));
-        // Main container sprites etc
-        dungeonContainer.querySelector('h2.pageItemTitle')?.after(new Comment("ko ifnot: EnhancedAutoClicker.disableAutoDungeonGraphics()"));
-        dungeonContainer.querySelector('h2.pageItemFooter')?.before(new Comment("/ko"));
     }
 
     /* Settings event handlers */
@@ -407,16 +371,6 @@ class EnhancedAutoClicker {
     static toggleAutoDungeonAlwaysOpenRareChests() {
         this.autoDungeonAlwaysOpenRareChests = !this.autoDungeonAlwaysOpenRareChests;
         localStorage.setItem('autoDungeonAlwaysOpenRareChests', this.autoDungeonAlwaysOpenRareChests);
-    }
-
-    static toggleAutoGymGraphics() {
-        this.gymGraphicsDisabled(!this.gymGraphicsDisabled());
-        localStorage.setItem('gymGraphicsDisabled', this.gymGraphicsDisabled());
-    }
-
-    static toggleAutoDungeonGraphics() {
-        this.dungeonGraphicsDisabled(!this.dungeonGraphicsDisabled());
-        localStorage.setItem('dungeonGraphicsDisabled', this.dungeonGraphicsDisabled());
     }
 
     static changeCalcEfficiencyDisplayMode(event) {

--- a/enhancedautohatchery.user.js
+++ b/enhancedautohatchery.user.js
@@ -5,7 +5,7 @@
 // @description   Automatically hatches eggs at 100% completion. Adds an On/Off button for auto hatching as well as an option for automatically hatching store bought eggs and dug up fossils.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       3.1.3
+// @version       3.1.4
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -298,7 +298,16 @@ function addGlobalStyle(css) {
     head.appendChild(style);
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -315,13 +324,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -347,9 +350,20 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('enhancedautohatchery') === 'true') {
-    loadEpheniaScript('enhancedautohatchery', initAutoHatch);
-    bindAutoHatcher();
+    loadEpheniaScript('enhancedautohatchery', initAutoHatch, bindAutoHatcher);
 }

--- a/enhancedautomine.user.js
+++ b/enhancedautomine.user.js
@@ -5,7 +5,7 @@
 // @description   Automatically mines the Underground with Bombs. Features adjustable settings as well.
 // @copyright     https://github.com/Ephenia
 // @license       GPL-3.0 License
-// @version       2.2.3
+// @version       2.2.4
 
 // @homepageURL   https://github.com/Ephenia/Pokeclicker-Scripts/
 // @supportURL    https://github.com/Ephenia/Pokeclicker-Scripts/issues
@@ -290,7 +290,16 @@ function addGlobalStyle(css) {
     head.appendChild(style);
 }
 
-function loadEpheniaScript(scriptName, initFunction) {
+function loadEpheniaScript(scriptName, initFunction, priorityFunction) {
+    function reportScriptError(scriptName, error) {
+        console.error(`Error while initializing '${scriptName}' userscript:\n${error}`);
+        Notifier.notify({
+            type: NotificationConstants.NotificationOption.warning,
+            title: scriptName,
+            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
+            timeout: GameConstants.DAY,
+        });
+    }
     const windowObject = !App.isUsingClient ? unsafeWindow : window;
     // Inject handlers if they don't exist yet
     if (windowObject.epheniaScriptInitializers === undefined) {
@@ -307,13 +316,7 @@ function loadEpheniaScript(scriptName, initFunction) {
                     try {
                         initFunction();
                     } catch (e) {
-                        console.error(`Error while initializing '${scriptName}' userscript:\n${e}`);
-                        Notifier.notify({
-                            type: NotificationConstants.NotificationOption.warning,
-                            title: scriptName,
-                            message: `The '${scriptName}' userscript crashed while loading. Check for updates or disable the script, then restart the game.\n\nReport script issues to the script developer, not to the Pokéclicker team.`,
-                            timeout: GameConstants.DAY,
-                        });
+                        reportScriptError(scriptName, e);
                     }
                 });
                 hasInitialized = true;
@@ -339,6 +342,18 @@ function loadEpheniaScript(scriptName, initFunction) {
     }
     // Add initializer for this particular script
     windowObject.epheniaScriptInitializers[scriptName] = initFunction;
+    // Run any functions that need to execute before the game starts
+    if (priorityFunction) {
+        $(document).ready(() => {
+            try {
+                priorityFunction();
+            } catch (e) {
+                reportScriptError(scriptName, e);
+                // Remove main initialization function  
+                windowObject.epheniaScriptInitializers[scriptName] = () => null;
+            }
+        });
+    }
 }
 
 if (!App.isUsingClient || localStorage.getItem('enhancedautomine') === 'true') {


### PR DESCRIPTION
Rewrote Additional Visual Settings with improvements and fixes for the new version.

Changes:
- Additional Visual Settings
  - Added support for disabling graphics in gyms, dungeons, and the battle frontier with separate settings for each
  - Added new setting to hide the party attack number (slow to calculate)
  - Removed setting to hide pokemon defeated number on routes (not slow to calculate)
  - Removed "Disable all notifications" setting as it was suppressing crash notifications*
  - Added auto-clicker support setting: if Enhanced Auto Clicker is also installed, it will only disable graphics while the auto clicker is running
- Enhanced Auto Clicker
  - Removed disable-graphics settings, as these are now part of AVS.
- All scripts
  - Improved crash reporting

*If someone needed this for a particular notification, ask the main devs to make a setting to hide it.

Fixes #413.